### PR TITLE
Nullius support

### DIFF
--- a/cybersyn/data-final-fixes.lua
+++ b/cybersyn/data-final-fixes.lua
@@ -1,0 +1,8 @@
+if mods["nullius"] then
+    -- Place combinator in the same subgroup as the regular train stop
+    data.raw["recipe"][COMBINATOR_NAME].subgroup = data.raw["train-stop"]["train-stop"].subgroup
+    data.raw["item"][COMBINATOR_NAME].subgroup = data.raw["item"]["train-stop"].subgroup
+    -- Nullius makes modded technologies part of its research tree
+    -- Place combinator in the same place on the research tree as LTN 
+    table.insert(data.raw.technology["nullius-broadcasting-1"].prerequisites, "cybersyn-train-network")
+end

--- a/cybersyn/prototypes/item.lua
+++ b/cybersyn/prototypes/item.lua
@@ -5,3 +5,7 @@ combinator_item.icon_size = 64
 combinator_item.icon_mipmaps = 4
 combinator_item.order = data.raw["item"]["decider-combinator"].order.."-b"
 combinator_item.place_result = COMBINATOR_NAME
+if (mods["nullius"]) then
+	-- Enable item in Nullius and place next to the regular train stop
+	combinator_item.order = "nullius-eca"
+end

--- a/cybersyn/prototypes/tech.lua
+++ b/cybersyn/prototypes/tech.lua
@@ -5,6 +5,18 @@ combinator_recipe.ingredients = {
 	{"advanced-circuit", 5},
 }
 combinator_recipe.enabled = false
+if (mods["nullius"]) then
+	-- Enable recipe and place it just after regular station
+	combinator_recipe.order = "nullius-eca"
+	-- Use the same costs (minus the train stop) and metadata as for LTN
+	combinator_recipe.category = "medium-crafting"
+	combinator_recipe.always_show_made_in = true
+	combinator_recipe.energy_required = 3
+	combinator_recipe.ingredients = {
+		{"arithmetic-combinator", 2},
+		{"green-wire", 4}
+	}
+end
 
 cybersyn_tech = {
 	type = "technology",
@@ -33,3 +45,19 @@ cybersyn_tech = {
 	},
 	order = "c-g-c"
 }
+
+if (mods["nullius"]) then
+	-- Enable technology
+	cybersyn_tech.order = "nullius-" .. (cybersyn_tech.order or "")
+	-- Use the same costs and requirements as for LTN
+	cybersyn_tech.unit = {
+		count = 100,
+		ingredients = {
+			{ "nullius-geology-pack", 1 }, { "nullius-climatology-pack", 1 },
+			{ "nullius-mechanical-pack", 1 }, { "nullius-electrical-pack", 1 }
+		},
+		time = 25
+	}
+	cybersyn_tech.prerequisites = { "nullius-checkpoint-optimization", "nullius-traffic-control" }
+	cybersyn_tech.ignore_cybersyn_tech_cost_multiplier = true
+end


### PR DESCRIPTION
Hi.

Here's a small PR for making this mod work with [Nullius](https://mods.factorio.com/mod/nullius) overhaul. It enables the items and recipes by prefixing their order with `nullius-` (which is how the mod decides what to keep enabled), and uses the same research and build costs as an LTN station.