### PR TITLE
addresses bug report (experimental) Non-recoverable error clearing network filter in GUI, reset_player crash on loading save

### DIFF
--- a/cybersyn/scripts/gui/main.lua
+++ b/cybersyn/scripts/gui/main.lua
@@ -165,4 +165,14 @@ function manager_gui.tick(global)
 	end
 end
 
+---@param i string|uint
+---@param v LuaPlayer
+function manager_gui.reset_player(i, v)
+	local player = game.get_player(i)
+	if player ~= nil then
+		v.refs.manager_window.destroy()
+		v.refs = manager.create(player)
+	end
+end
+
 return manager_gui

--- a/cybersyn/scripts/migrations.lua
+++ b/cybersyn/scripts/migrations.lua
@@ -321,7 +321,7 @@ local migrations_table = {
 
 ---@param data ConfigurationChangedData
 function on_config_changed(data)
-	for i, v in pairs(game.players) do
+	for i, v in pairs(global.manager.players) do
 		manager_gui.reset_player(i, v)
 	end
 	global.tick_state = STATE_INIT


### PR DESCRIPTION
It appears you set a migration to run a non-existent function, so I implemented it and modified the data being passed in to be the correct type