### PR TITLE
Crash fix for 1.2.13 -> 1.2.14 migration with GUI enabled

### DIFF
--- a/cybersyn/scripts/migrations.lua
+++ b/cybersyn/scripts/migrations.lua
@@ -321,8 +321,10 @@ local migrations_table = {
 
 ---@param data ConfigurationChangedData
 function on_config_changed(data)
-	for i, v in pairs(global.manager.players) do
-		manager_gui.reset_player(i, v)
+	if global.manager then
+		for i, v in pairs(global.manager.players) do
+			manager_gui.reset_player(i, v)
+		end
 	end
 	global.tick_state = STATE_INIT
 	global.tick_data = {}


### PR DESCRIPTION
Attempt to call `reset_player` on save that hasn't had manager initialized causes crash, resolved by wrapping offending statement in if global.manager block