### PR TITLE
Remove LTNManager hard incompatibility flag in info.json

### DIFF
--- a/cybersyn/info.json
+++ b/cybersyn/info.json
@@ -11,7 +11,6 @@
         "? space-exploration >= 0.6.94",
         "? miniloader",
         "? nullius",
-        "? pypostprocessing",
-        "! LtnManager"
+        "? pypostprocessing"
     ]
 }


### PR DESCRIPTION
Tested that both GUIs would work on a save with both LTN and Cybersyn active, appears to be fine, so, removing the incompatibility flag as it's not necessary.