### PR TITLE
Fix Nullius overwriting localised names

### DIFF
--- a/cybersyn/prototypes/entity.lua
+++ b/cybersyn/prototypes/entity.lua
@@ -13,6 +13,9 @@ combinator_entity.radius_visualisation_specification = {
 }
 combinator_entity.active_energy_usage = "10KW"
 
+if mods["nullius"] then
+	combinator_entity.localised_name = { "entity-name.cybersyn-combinator" }
+end
 
 local COMBINATOR_SPRITE = "__cybersyn__/graphics/combinator/cybernetic-combinator.png"
 local COMBINATOR_HR_SPRITE = "__cybersyn__/graphics/combinator/hr-cybernetic-combinator.png"

--- a/cybersyn/prototypes/item.lua
+++ b/cybersyn/prototypes/item.lua
@@ -7,6 +7,7 @@ combinator_item.subgroup = data.raw["item"]["train-stop"].subgroup
 combinator_item.order = data.raw["item"]["train-stop"].order.."-b"
 combinator_item.place_result = COMBINATOR_NAME
 if mods["nullius"] then
+	combinator_item.localised_name = { "item-name.cybersyn-combinator" }
 	-- Enable item in Nullius and place next to the regular train stop
 	combinator_item.order = "nullius-eca"
 end


### PR DESCRIPTION
Nullius modifies the names of some base items by writing to their
`localised_name` property. This modification is done before the
modified tables are copied and used by other mods (possibly depending on
load order).

As such, if mods use custom names from a `*.cfg` file, they will not be
respected unless the mod also writes to the `localised_name` property in
Lua code during the data stage.

Example in a Nullius save before the fix:

![cybersyn_nullius_localisedname](https://user-images.githubusercontent.com/551094/228987584-37e613da-57c8-491d-af84-4018536d6dfd.png)

And after applying the fix:

![cybersyn_nullius_localisedname_fixed](https://user-images.githubusercontent.com/551094/228987611-23207451-e537-44b7-9988-d07880904ade.png)
