### PR TITLE
Fix Issue with debug revision breaking saves

### DIFF
--- a/cybersyn/scripts/migrations.lua
+++ b/cybersyn/scripts/migrations.lua
@@ -346,21 +346,28 @@ end
 
 ---NOTE: this runs before on_config_changed
 ---It does not have access to game
+---NOTE 2: Everything in this section must be idempotent
 function on_debug_revision_change()
 	local map_data = global
 
 	if debug_revision == 1 then
 		for _, e in pairs(map_data.refuelers) do
-			e.network_mask = e.network_flag
-			e.network_flag = nil
+			if e.network_flag ~= nil then
+				e.network_mask = e.network_flag
+				e.network_flag = nil
+			end
 		end
 		for _, e in pairs(map_data.stations) do
-			e.network_mask = e.network_flag
-			e.network_flag = nil
+			if e.network_flag ~= nil then
+				e.network_mask = e.network_flag
+				e.network_flag = nil
+			end
 		end
 		for _, e in pairs(map_data.trains) do
-			e.network_mask = e.network_flag
-			e.network_flag = nil
+			if e.network_flag ~= nil then
+				e.network_mask = e.network_flag
+				e.network_flag = nil
+			end
 		end
 	end
 end


### PR DESCRIPTION
Fixes an idempotency issue in the `network_flag` -> `network_mask` migration in the recently added debug revision code, along with a note for the future that idempotency is required for anything that runs under that function.

Closes https://discord.com/channels/1058170227000606811/1090788697328332870 - I was able to replicate and confirm behavior and fix on my own unmigrated save.
May close https://discord.com/channels/1058170227000606811/1090030446697529344 waiting on confirmation