### PR TITLE
Bind the on_gui_closed event for manager_window

### DIFF
--- a/cybersyn/prototypes/gui-style.lua
+++ b/cybersyn/prototypes/gui-style.lua
@@ -370,6 +370,14 @@ if settings.startup["cybersyn-manager-enabled"].value then
       key_sequence = "CONTROL + T",
       action = "lua",
     },
+    {
+      type = "custom-input",
+      name = "cybersyn-manager-confirm-gui",
+      key_sequence = "",
+      action = "lua",
+      linked_game_control = "confirm-gui"
+    },
+    -- TODO: bind this input to focusing on the station_name box
     --{
     --  type = "custom-input",
     --  name = "ltnm-linked-focus-search",

--- a/cybersyn/prototypes/gui-style.lua
+++ b/cybersyn/prototypes/gui-style.lua
@@ -370,14 +370,6 @@ if settings.startup["cybersyn-manager-enabled"].value then
       key_sequence = "CONTROL + T",
       action = "lua",
     },
-    {
-      type = "custom-input",
-      name = "cybersyn-manager-confirm-gui",
-      key_sequence = "",
-      action = "lua",
-      linked_game_control = "confirm-gui"
-    },
-    -- TODO: bind this input to focusing on the station_name box
     --{
     --  type = "custom-input",
     --  name = "ltnm-linked-focus-search",

--- a/cybersyn/scripts/gui/main.lua
+++ b/cybersyn/scripts/gui/main.lua
@@ -47,7 +47,7 @@ end
 local manager_gui = {}
 
 function manager_gui.on_lua_shortcut(e)
-	if e.prototype_name == "cybersyn-toggle-gui" or e.input_name == "cybersyn-toggle-gui" then
+	if e.prototype_name == "cybersyn-toggle-gui" or e.input_name == "cybersyn-toggle-gui" or e.element.name == "manager_window" then
 		manager.wrapper(e, manager.handle.manager_toggle)
 	end
 end

--- a/cybersyn/scripts/gui/main.lua
+++ b/cybersyn/scripts/gui/main.lua
@@ -47,8 +47,14 @@ end
 local manager_gui = {}
 
 function manager_gui.on_lua_shortcut(e)
-	if e.prototype_name == "cybersyn-toggle-gui" or e.input_name == "cybersyn-toggle-gui" or e.element.name == "manager_window" then
-		manager.wrapper(e, manager.handle.manager_toggle)
+	if e.prototype_name == "cybersyn-toggle-gui" or e.input_name == "cybersyn-toggle-gui" or e.element then
+		if e.element then
+			if e.element.name == "manager_window" then
+				manager.wrapper(e, manager.handle.manager_toggle)	
+			end
+		else			
+			manager.wrapper(e, manager.handle.manager_toggle)
+		end
 	end
 end
 

--- a/cybersyn/scripts/main.lua
+++ b/cybersyn/scripts/main.lua
@@ -955,6 +955,7 @@ local function main()
 		script.on_event(defines.events.on_player_removed, manager.on_player_removed)
 		script.on_event(defines.events.on_player_created, manager.on_player_created)
 		script.on_event(defines.events.on_lua_shortcut, manager.on_lua_shortcut)
+		script.on_event(defines.events.on_gui_closed, manager.on_lua_shortcut)
 		script.on_event("cybersyn-toggle-gui", manager.on_lua_shortcut)
 	end
 


### PR DESCRIPTION
Minor enough change that it should be fine going straight into `beta` and can get backported up to `dev`

Multiple people have asked for it, and I'm tired of it being asked to be implemented at this point