### PR TITLE
Fix edge case registering script.on_nth_tick() handlers in script/main.lua

### DIFF
--- a/cybersyn/scripts/main.lua
+++ b/cybersyn/scripts/main.lua
@@ -847,17 +847,26 @@ local function grab_all_settings()
 end
 local function register_tick()
 	script.on_nth_tick(nil)
-	if mod_settings.tps > DELTA then
-		local nth_tick_main = ceil(60/mod_settings.tps)--[[@as uint]]
-		script.on_nth_tick(nth_tick_main, function()
+	--edge case catch to register both main and manager tick if they're scheduled to run on the same ticks
+	if mod_settings.manager_enabled and mod_settings.manager_ups == mod_settings.tps and mod_settings.tps > DELTA then
+		local nth_tick = ceil(60/mod_settings.tps)
+		script.on_nth_tick(nth_tick, function()
 			tick(global, mod_settings)
-		end)
-	end
-	if mod_settings.manager_enabled and mod_settings.manager_ups > DELTA then
-		local nth_tick_manager = ceil(60/mod_settings.manager_ups)--[[@as uint]]
-		script.on_nth_tick(nth_tick_manager, function()
 			manager.tick(global)
 		end)
+	else
+		if mod_settings.tps > DELTA then
+			local nth_tick_main = ceil(60/mod_settings.tps)--[[@as uint]]
+			script.on_nth_tick(nth_tick_main, function()
+				tick(global, mod_settings)
+			end)
+		end
+		if mod_settings.manager_enabled and mod_settings.manager_ups > DELTA then
+			local nth_tick_manager = ceil(60/mod_settings.manager_ups)--[[@as uint]]
+			script.on_nth_tick(nth_tick_manager, function()
+				manager.tick(global)
+			end)
+		end
 	end
 end
 local function on_settings_changed(event)


### PR DESCRIPTION
Referencing
https://discord.com/channels/1058170227000606811/1091742940507930674

Not sure if this is the most elegant way to fix it, but, it checks for the edge case where the original code was going to have the original handler for the nth tick overwritten by the manager tick function, causing the main tick loop to not fire.

Requesting review to determine if you'd rather redo this portion of code yourself rather than accept this PR as-is.