### PR TITLE
Force inactivity timer on pickups to prevent inserter overflows

### DIFF
--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -139,6 +139,8 @@ function create_loading_order(stop, manifest, enable_inactive)
 			compare_type = "and",
 			condition = {comparator = "≥", first_signal = {type = item.type, name = item.name}, constant = item.count}
 		}
+
+		condition[#condition + 1] = condition_wait_inactive
 	end
 	if enable_inactive then
 		condition[#condition + 1] = condition_wait_inactive


### PR DESCRIPTION
I've noticed that trains will depart stations too soon, and not allow the inserters to finish inserting the items into the train before departing. This leaves multi provider stations in a state where leftover cargo is sometimes inserted into the next train, causing issues.

LTN specifically has this wait condition as well, to ensure inserters finish their swing before the train departs. While this does at a minor 1s delay, it will ensure that no trains get stuck because inserters inserted wrong items into the train.