### PR TITLE
Avoid empty manifests when using provider item thresholds

### DIFF
--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -157,11 +157,17 @@ function create_manifest(map_data, r_station_id, p_station_id, train_id, primary
 			end
 			local p_effective_item_count = p_station.item_p_counts[item_name]
 			--could be an item that is not present at the station
+			local effective_threshold
 			local override_threshold = p_station.item_thresholds and p_station.item_thresholds[item_name]
 			if override_threshold and p_station.is_stack and item_type == "item" then
 				override_threshold = override_threshold*get_stack_size(map_data, item_name)
 			end
-			if p_effective_item_count and p_effective_item_count >= (override_threshold or r_threshold) then
+			if override_threshold and override_threshold <= r_threshold then
+				effective_threshold = override_threshold
+			else
+				effective_threshold = r_threshold
+			end
+			if p_effective_item_count and p_effective_item_count >= effective_threshold then
 				local item = {name = item_name, type = item_type, count = min(-r_effective_item_count, p_effective_item_count)}
 				if item_name == primary_item_name then
 					manifest[#manifest + 1] = manifest[1]


### PR DESCRIPTION
This should fix the bug [reported on discord](https://discord.com/channels/1058170227000606811/1106621106380619856) where high item thresholds result in empty manifests. Empty manifests cause trains to go on pointless runs, endlessly.

An empty manifest can be generated when the central planning logic and manifest creation logic disagree on what threshold is to be used for the primary item: the central planner thinks that a delivery should be generated for that item, but the manifest creation doesn't. Specifically, this happens when `r_threshold` is less than `p_station.item_thresholds[item_name]` for the primary item. (The bug also happens for non-primary items, but it wouldn't result in empty deliveries.)

A deeper fix would be to abstract out the logic for "what is the weight (if any) of the graph edge from p to r, with label item_name?" which could be used in both places. But a naive implementation of this idea would re-calculate some info on the r side for every p, and that requires some delicate engineering to avoid, so I won't try to make such a huge change.