### PR TITLE
Manager GUI: improve control signals and thresholds

### DIFF
--- a/cybersyn/scripts/gui/inventory.lua
+++ b/cybersyn/scripts/gui/inventory.lua
@@ -132,10 +132,17 @@ function inventory_tab.build(map_data, player_data)
               inventory_provided[item.name] = inventory_provided[item.name] + count
             end
           else
-            if inventory_requested[item.name] == nil then
-              inventory_requested[item.name] = count
-            else
-              inventory_requested[item.name] = inventory_requested[item.name] + count
+            local r_threshold = station.item_thresholds and station.item_thresholds[item.name] or station.r_threshold
+            if station.is_stack and item_type == "item" then
+              r_threshold = r_threshold*get_stack_size(map_data, item.name)
+            end
+
+            if -count >= r_threshold then
+              if inventory_requested[item.name] == nil then
+                inventory_requested[item.name] = count
+              else
+                inventory_requested[item.name] = inventory_requested[item.name] + count
+              end
             end
           end
         end

--- a/cybersyn/scripts/gui/stations.lua
+++ b/cybersyn/scripts/gui/stations.lua
@@ -250,7 +250,7 @@ function stations_tab.build(map_data, player_data, query_limit)
 
 		gui.add(refs.provided_requested_table, util.slot_table_build_from_station(station))
 		gui.add(refs.shipments_table, util.slot_table_build_from_deliveries(station))
-		gui.add(refs.control_signals_table, util.slot_table_build_from_control_signals(station))
+		gui.add(refs.control_signals_table, util.slot_table_build_from_control_signals(station, map_data))
 
 	end
 

--- a/cybersyn/scripts/gui/util.lua
+++ b/cybersyn/scripts/gui/util.lua
@@ -171,10 +171,11 @@ end
 
 --- @param station Station
 --- @return GuiElemDef[]
-function util.slot_table_build_from_control_signals(station)
+function util.slot_table_build_from_control_signals(station, map_data)
   ---@type GuiElemDef[]
   local children = {}
   local comb1_signals, comb2_signals = get_signals(station)
+
   if comb1_signals then
     for _, v in pairs(comb1_signals) do
       local item = v.signal
@@ -205,6 +206,68 @@ function util.slot_table_build_from_control_signals(station)
       ::continue::
     end
   end
+
+  if comb2_signals then
+    for _, v in pairs(comb2_signals) do
+      local item = v.signal
+      local count = v.count
+      local name = item.name
+      local sprite = ""
+      local color = "default"
+
+      if item.type == "item" or item.type == "fluid" then
+        local sprite, img_path, item_string = util.generate_item_references(name)
+        if sprite ~= nil then
+          local color
+          if count > 0 then
+            color = "green"
+          else
+            color = "blue"
+          end
+        end
+
+        if station.is_stack and item.type == "item" then
+          count = count * get_stack_size(map_data, name)
+        end
+
+        if game.is_valid_sprite_path(sprite) then
+          children[#children + 1] = {
+            type = "sprite-button",
+            enabled = false,
+            style = "ltnm_small_slot_button_" .. color,
+            sprite = sprite,
+            tooltip = {
+              "",
+              img_path,
+              item_string,
+              "\n"..format.number(count),
+            },
+            number = count
+          }
+        end
+
+      elseif item.type == "virtual" then
+        sprite = "virtual-signal" .. "/" .. name
+        if game.is_valid_sprite_path(sprite) then
+          children[#children + 1] = {
+            type = "sprite-button",
+            enabled = false,
+            style = "ltnm_small_slot_button_" .. color,
+            sprite = sprite,
+            tooltip = {
+              "",
+              "[img=virtual-signal." .. name  .. "]",
+              { "virtual-signal-name." .. name },
+              "\n"..format.number(count),
+            },
+            number = count
+          }
+        end
+      end
+      ::continue::
+    end
+  end
+
   return children
 end
 


### PR DESCRIPTION
Improvements to the manager GUI to allow a easier assessment of open requests and station configuration.

## Include "Station Control" signals in the signal column
This provides a more accurate view of the station configuration in the manager GUI. Previously those signals were missing from the GUI and it was not always clear why a station doesn't receive deliveries.

## Excludes requests <= request threshold for that station from inventory view
Requests that do not trigger exceed the threshold won't generate deliveries. With those requests excluded unfulfilled requests become much more apparent, quickly allowing identification of open requests. With many stations having many partial requests it was previously much more difficult to identify potential problems.