### PR TITLE
fixed provide/request orders for the same item getting generated simultaneously

### DIFF
--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -304,6 +304,12 @@ local function tick_dispatch(map_data, mod_settings)
 				goto continue
 			end
 
+			--don't request when already providing
+			local item_deliveries = station.deliveries[item_name]
+			if item_deliveries and item_deliveries < 0 then
+				goto continue
+			end
+
 			r_station_i = i
 			r_threshold = threshold
 			best_r_prior = prior
@@ -348,7 +354,7 @@ local function tick_dispatch(map_data, mod_settings)
 		---@type uint
 		local j = 1
 		while j <= #p_stations do
-			local p_flag, r_flag, netand, best_p_train_id, best_t_prior, best_capacity, best_t_to_p_dist, effective_count, override_threshold, p_prior, best_p_to_r_dist, effective_threshold, slot_threshold
+			local p_flag, r_flag, netand, best_p_train_id, best_t_prior, best_capacity, best_t_to_p_dist, effective_count, override_threshold, p_prior, best_p_to_r_dist, effective_threshold, slot_threshold, item_deliveries
 
 			local p_station_id = p_stations[j]
 			local p_station = stations[p_station_id]
@@ -480,6 +486,12 @@ local function tick_dispatch(map_data, mod_settings)
 				end
 			end
 			if not best_p_train_id then
+				goto p_continue
+			end
+
+			--don't provide when already requesting
+			item_deliveries = p_station.deliveries[item_name]
+			if item_deliveries and item_deliveries > 0 then
 				goto p_continue
 			end
 


### PR DESCRIPTION
I believe this should prevent https://github.com/mamoniot/project-cybersyn/issues/120 from happening in the future. The issue was that for stations set to both provide and request, changing the request targets or overfilling stations could result in provide/request orders being generated at the same time, which would then cancel each other out, causing the deliveries entry to be set to nil and later causing crashes.

Note that this fix won't fix saves already experiencing this issue, so we may want to add something to migrations for those cases? I'm pretty sure this issue is pretty rare and everyone who has experienced it has just rolled back to an autosave.