### PR TITLE
remove old check for each on depots

### DIFF
--- a/cybersyn/scripts/gui.lua
+++ b/cybersyn/scripts/gui.lua
@@ -89,13 +89,6 @@ local function handle_drop_down(e)
 		set_comb_operation(comb, MODE_PRIMARY_IO)
 	elseif element.selected_index == 2 then
 		set_comb_operation(comb, MODE_DEPOT)
-		--prevent the use of the each signal with depots
-		local network = element.parent.parent.bottom.network--[[@as LuaGuiElement]]
-		local signal = network.elem_value--[[@as SignalID]]
-		if signal and (signal.name == NETWORK_EACH) then
-			network.elem_value = nil
-			set_comb_network_name(comb, nil)
-		end
 	elseif element.selected_index == 3 then
 		set_comb_operation(comb, MODE_REFUELER)
 	elseif element.selected_index == 4 then


### PR DESCRIPTION
https://github.com/mamoniot/project-cybersyn/pull/103 fixed a crash in the gui, but I'm pretty sure this whole block should be removed, as you can set depots to each just fine since 7d2f0c2ccd1721af287d38984c6398b15da7557d. Keeping that block appears to have just been a minor oversight, so this PR just removes it entirely.