### PR TITLE
fix: make sure to init global.manager prior to migrations

### DIFF
--- a/cybersyn/scripts/gui/main.lua
+++ b/cybersyn/scripts/gui/main.lua
@@ -147,6 +147,9 @@ end
 
 
 function manager_gui.on_migration()
+    if global.manager == nil do
+        manager_gui.on_init()
+    end
 	for i, v in pairs(global.manager.players) do
 		manager_gui.reset_player(i, v)
 	end


### PR DESCRIPTION
Refer to [this bug](https://discord.com/channels/1058170227000606811/1158952732162535575) in discord.

Reproduction Steps:
1. Load up the save (EI_Backup)
2. Make sure start mod setting for Project Cybersyn is enabled for the indev manager
3. Try to load the save and observe the crash
<img width="355" alt="image" src="https://github.com/mamoniot/project-cybersyn/assets/98995/4235e6b7-3688-464d-88eb-2a3f79137333">

[EI_Backup.zip](https://github.com/mamoniot/project-cybersyn/files/12811444/EI_Backup.zip)

