### PR TITLE
make on_combinator_built search for straight rails by type

### DIFF
--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -49,11 +49,7 @@ function se_get_space_elevator_name(cache, surface)
 
 	if not entity or not entity.valid then
 		--Caching failed, default to expensive lookup
-		entity = surface.find_entities_filtered({
-			name = SE_ELEVATOR_STOP_PROTO_NAME,
-			type = "train-stop",
-			limit = 1,
-		})[1]
+		entity = surface.find_entities_filtered({name = SE_ELEVATOR_STOP_PROTO_NAME, limit = 1})[1]
 
 		if entity then
 			cache.se_get_space_elevator_name[cache_idx] = entity


### PR DESCRIPTION
Previously it was searching by name. This should fix https://github.com/mamoniot/project-cybersyn/issues/137 and https://discord.com/channels/1058170227000606811/1166735400660914246/1166735400660914246. Also cleaned up a couple other overspecified searches I found while checking there weren't any other similar issues.