### PR TITLE
Manager GUI: fix stack thresholds

### DIFF
--- a/cybersyn/scripts/gui/inventory.lua
+++ b/cybersyn/scripts/gui/inventory.lua
@@ -133,7 +133,7 @@ function inventory_tab.build(map_data, player_data)
             end
           else
             local r_threshold = station.item_thresholds and station.item_thresholds[item.name] or station.r_threshold
-            if station.is_stack and item_type == "item" then
+            if station.is_stack and item.type == "item" then
               r_threshold = r_threshold*get_stack_size(map_data, item.name)
             end
 


### PR DESCRIPTION
Fix https://github.com/mamoniot/project-cybersyn/pull/115
To excludes requests <= request threshold for that station from inventory view