### PR TITLE
Allow negative fuel threshold for wider mod compatibility

### DIFF
--- a/cybersyn/settings.lua
+++ b/cybersyn/settings.lua
@@ -67,7 +67,7 @@ data:extend({
 		order = "be",
 		setting_type = "runtime-global",
 		default_value = .5,
-		minimum_value = 0,
+		minimum_value = -1,
 		maximum_value = 1,
 	},
 	{


### PR DESCRIPTION
This change allows "bypass depo" to work with mods that insert fuel to the train only after it runs out of it, for example this mod:

https://mods.factorio.com/mod/Electronic_Locomotives