### PR TITLE
SE - Resolved crash when a train with a cybersyn schedule is on a shi…

### DIFF
--- a/cybersyn/info.json
+++ b/cybersyn/info.json
@@ -1,6 +1,6 @@
 {
     "name": "cybersyn",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "title": "Project Cybersyn",
     "author": "Mami",
     "factorio_version": "1.1",

--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -163,7 +163,7 @@ end
 
 ---@param stop LuaEntity
 function create_direct_to_station_order(stop)
-	return {rail = stop.connected_rail, rail_direction = stop.connected_rail_direction, wait_conditions = condition_direct_to_station}
+	return {rail = stop.connected_rail, rail_direction = stop.connected_rail_direction, wait_conditions = condition_direct_to_station, temporary = true}
 end
 
 ---@param train LuaTrain


### PR DESCRIPTION
Resolves issue similarly named in discord.
SE - Resolved crash when a train with a cybersyn schedule is on a ship when it takes off. 
- Switching Train Stop location stops to be temporary stops instead of gps hard coded.
