### PR TITLE
Some more 2.0 additions

### DIFF
--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -588,6 +588,7 @@ local function tick_poll_station(map_data, mod_settings)
 				local item_name = v.signal.name
 				local item_count = v.count
 				local item_type = v.signal.type
+				-- FIXME handle v.signal.quality
 				if item_name then
 					if item_type == "virtual" then
 						if item_name == SIGNAL_PRIORITY then
@@ -605,6 +606,7 @@ local function tick_poll_station(map_data, mod_settings)
 			local item_name = v.signal.name
 			local item_count = v.count
 			local item_type = v.signal.type
+			-- FIXME handle v.signal.quality
 			if item_name then
 				if item_type == "virtual" then
 					if item_name == SIGNAL_PRIORITY then

--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -689,40 +689,8 @@ end
 function set_combinator_output(map_data, comb, signals)
 	local out = map_data.to_output[comb.unit_number]
 	if out.valid then
-		--out.get_or_create_control_behavior().parameters = signals
-		local constBehaviour = out.get_or_create_control_behavior()
-
-		if constBehaviour.sections == nil or constBehaviour.sections_count == 0 then
-			constBehaviour.add_section()
-		end
-
-		if constBehaviour.sections and constBehaviour.sections_count > 0 then
-			if constBehaviour.sections_count > 1 then
-				--only the default section, messy but whatever
-				local i = 1
-				for _,v in pairs(constBehaviour.sections) do
-					if i ~= 1 then
-						constBehaviour.removeSection(i)
-					end
-					i = i + 1
-				end
-			end
-
-			local primarySection = constBehaviour.get_section(1)
-			local filters = {}
-			if signals ~= nil then
-				for _,v in pairs(signals) do
-					local filt = {
-						type = v.signal.type,
-						name = v.signal.name,
-						quality = nil,
-						comparator = nil
-					}
-					table.insert(filters, filt)
-				end
-			end
-			primarySection.filters = filters
-		end
+		-- out is a non-interactable, invisible combinator whiche means players cannot change the number of sections
+		out.get_or_create_control_behavior().get_section(1).filters = signals or {}
 	end
 end
 
@@ -757,7 +725,8 @@ function set_comb2(map_data, station)
 		for item_name, count in pairs(deliveries) do
 			local i = #signals + 1
 			local is_fluid = prototypes.item[item_name] == nil--NOTE: this is expensive
-			signals[i] = {index = i, signal = {type = is_fluid and "fluid" or "item", name = item_name}, count = sign*count}
+			-- FIXME: the circuit network can only carry exact qualities, so deliveries must provide each quality separately
+			signals[i] = {value = {type = is_fluid and "fluid" or "item", name = item_name, quality = "normal", comparator = "="}, min = sign*count} -- constant combinator cannot have quality = nil (any)
 		end
 		set_combinator_output(map_data, station.entity_comb2, signals)
 	end

--- a/cybersyn/scripts/global.lua
+++ b/cybersyn/scripts/global.lua
@@ -102,6 +102,7 @@
 ---@class ManifestEntry
 ---@field public type string
 ---@field public name string
+---@field public quality string
 ---@field public count int
 
 ---@class Economy

--- a/cybersyn/scripts/gui/inventory.lua
+++ b/cybersyn/scripts/gui/inventory.lua
@@ -100,6 +100,7 @@ function inventory_tab.build(map_data, player_data)
 			if comb1_signals then
 				for _, signal_ID in pairs(comb1_signals) do
 					local item = signal_ID.signal.name
+          -- FIXME handle signal_ID.signal.quality
 					if item then
 						if item == search_item then
 							goto has_match
@@ -136,6 +137,7 @@ function inventory_tab.build(map_data, player_data)
             if station.is_stack and item_type == "item" then
               r_threshold = r_threshold*get_stack_size(map_data, item.name)
             end
+            -- FIXME handle v.signal.quality
 
             if -count >= r_threshold then
               if inventory_requested[item.name] == nil then

--- a/cybersyn/scripts/gui/stations.lua
+++ b/cybersyn/scripts/gui/stations.lua
@@ -133,6 +133,7 @@ function stations_tab.build(map_data, player_data, query_limit)
 			if comb1_signals then
 				for _, signal_ID in pairs(comb1_signals) do
 					local item = signal_ID.signal.name
+					-- FIXME handle signal_ID.signal.quality
 					if item then
 						if item == search_item then
 							goto has_match

--- a/cybersyn/scripts/gui/util.lua
+++ b/cybersyn/scripts/gui/util.lua
@@ -104,6 +104,7 @@ function util.slot_table_build_from_station(station)
       end
       local count = v.count
       local name = item.name
+      -- FIXME handle item.quality
       local sprite, img_path, item_string = util.generate_item_references(name)
       if sprite ~= nil then
         local color
@@ -181,6 +182,7 @@ function util.slot_table_build_from_control_signals(station, map_data)
       local item = v.signal
       local count = v.count
       local name = item.name
+      -- FIXME handle item.quality
       local sprite = ""
       local color = "default"
       if item.type ~= "virtual" then

--- a/cybersyn/scripts/main.lua
+++ b/cybersyn/scripts/main.lua
@@ -259,11 +259,13 @@ local function on_combinator_built(map_data, comb)
 		force = comb.force
 	})
 	assert(out, "cybersyn: could not spawn combinator controller")
-	local wireConnectorRed = comb.get_wire_connector(defines.wire_connector_id.circuit_red, true)
-	local wireConnectorGreen = comb.get_wire_connector(defines.wire_connector_id.circuit_green, true)
+	local comb_red = comb.get_wire_connector(defines.wire_connector_id.combinator_output_red, true)
+	local out_red = out.get_wire_connector(defines.wire_connector_id.circuit_red, true)
+	out_red.connect_to(comb_red, false, defines.wire_origin.script)
 
-	wireConnectorRed.connect_to(out.get_wire_connector(defines.wire_connector_id.circuit_red, true))
-	wireConnectorGreen.connect_to(out.get_wire_connector(defines.wire_connector_id.circuit_green, true))
+	local comb_green = comb.get_wire_connector(defines.wire_connector_id.combinator_output_green, true)
+	local out_green = out.get_wire_connector(defines.wire_connector_id.circuit_green, true)
+	out_green.connect_to(comb_green, false, defines.wire_origin.script)
 
 	local control = get_comb_control(comb)
 	local params = control.parameters

--- a/cybersyn/scripts/train-events.lua
+++ b/cybersyn/scripts/train-events.lua
@@ -13,7 +13,7 @@ local function set_comb1(map_data, station, manifest, sign)
 		if manifest then
 			local signals = {}
 			for i, item in ipairs(manifest) do
-				signals[i] = {index = i, signal = {type = item.type, name = item.name}, count = sign*item.count}
+				signals[i] = {value = {type = item.type, name = item.name, quality = item.quality or "normal", comparator = "="}, min = sign*item.count}
 			end
 			set_combinator_output(map_data, comb, signals)
 		else


### PR DESCRIPTION
I refactored quality handling which allows to simplify `set_combinator_output` drastically.
I also refactored `update_stop_from_rail` to use the new `get_rail_segment_stop`.

I believe Cybersyn needs to handle quality through deliveries because to my understanding the circuit network can only transport signals with exact qualities and those signals can only set exact inserter filters. For now I hardcoded comparator=`=` and quality=`normal` but I also marked all the relevant code location I found and that deal with signals with a `FIXME`.

There's also a bug for new cybersyn combinators. The invisible, internal output combinator gets connected to the inputs of new cybersyn combinators. It must be connected to the outputs instead.