### PR TITLE
signal.type = item needs to consider nil

### DIFF
--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -147,7 +147,7 @@ function create_manifest(map_data, r_station_id, p_station_id, train_id, primary
 	for k, v in pairs(r_station.tick_signals) do
 		---@type string
 		local item_name = v.signal.name
-		local item_type = v.signal.type
+		local item_type = v.signal.type or "item"
 		local r_item_count = v.count
 		local r_effective_item_count = r_item_count + (r_station.deliveries[item_name] or 0)
 		if r_effective_item_count < 0 and r_item_count < 0 then
@@ -168,6 +168,7 @@ function create_manifest(map_data, r_station_id, p_station_id, train_id, primary
 				effective_threshold = r_threshold
 			end
 			if p_effective_item_count and p_effective_item_count >= effective_threshold then
+				-- FIXME manifest entry needs quality
 				local item = {name = item_name, type = item_type, count = min(-r_effective_item_count, p_effective_item_count)}
 				if item_name == primary_item_name then
 					manifest[#manifest + 1] = manifest[1]
@@ -262,7 +263,7 @@ local function tick_dispatch(map_data, mod_settings)
 		if r_stations then
 			if p_stations then
 				item_name = signal.name--[[@as string]]
-				item_type = signal.type
+				item_type = signal.type or "item"
 				break
 			else
 				for i, id in ipairs(r_stations) do
@@ -587,7 +588,7 @@ local function tick_poll_station(map_data, mod_settings)
 			for k, v in pairs(comb2_signals) do
 				local item_name = v.signal.name
 				local item_count = v.count
-				local item_type = v.signal.type
+				local item_type = v.signal.type or "item"
 				-- FIXME handle v.signal.quality
 				if item_name then
 					if item_type == "virtual" then
@@ -605,7 +606,7 @@ local function tick_poll_station(map_data, mod_settings)
 		for k, v in pairs(comb1_signals) do
 			local item_name = v.signal.name
 			local item_count = v.count
-			local item_type = v.signal.type
+			local item_type = v.signal.type or "item"
 			-- FIXME handle v.signal.quality
 			if item_name then
 				if item_type == "virtual" then
@@ -632,7 +633,7 @@ local function tick_poll_station(map_data, mod_settings)
 		for k, v in pairs(comb1_signals) do
 			---@type string
 			local item_name = v.signal.name
-			local item_type = v.signal.type
+			local item_type = v.signal.type or "item"
 			local item_count = v.count
 			local effective_item_count = item_count + (station.deliveries[item_name] or 0)
 

--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -490,7 +490,7 @@ function set_train_from_comb(mod_settings, train, comb)
 	if signals then
 		for k, v in pairs(signals) do
 			local item_name = v.signal.name
-			local item_type = v.signal.type
+			local item_type = v.signal.type or "item"
 			local item_count = v.count
 			if item_name then
 				if item_type == "virtual" then
@@ -538,7 +538,7 @@ function set_refueler_from_comb(map_data, mod_settings, id, refueler)
 	if signals then
 		for k, v in pairs(signals) do
 			local item_name = v.signal.name
-			local item_type = v.signal.type
+			local item_type = v.signal.type or "item"
 			local item_count = v.count
 			if item_name then
 				if item_type == "virtual" then

--- a/cybersyn/scripts/gui/trains.lua
+++ b/cybersyn/scripts/gui/trains.lua
@@ -165,7 +165,7 @@ function trains_tab.build(map_data, player_data, query_limit)
 					local primary_item1 = train1.manifest[1]
 					local primary_item2 = train2.manifest[1]
 					if primary_item1.name ~= primary_item2.name then
-						return invert ~= (primary_item1.type == primary_item2.type and primary_item1.name < primary_item2.name or primary_item1.type == "item")
+						return invert ~= (primary_item1.type == primary_item2.type and primary_item1.name < primary_item2.name or (not primary_item1.type or primary_item1.type == "item"))
 					elseif primary_item1.count ~= primary_item2.count then
 						return invert ~= (primary_item1.count < primary_item2.count)
 					end


### PR DESCRIPTION
`signal.type == nil` is equivalent to `signal.type == "item"` and needs to be treated as such.

I searched for `.type` and modified all occurrences that seemed relevant.

For some contexts adding `or "item"` is redundant right now because the field isn't checked for `== "item"` in that particular context. But I though it safe and future-proof to add it anyway.

This also fixes stack threshold because they are only considered for `signal.type == "item"`.