### PR TITLE
migrate get_train_stops for 2.0

### DIFF
--- a/cybersyn/scripts/main.lua
+++ b/cybersyn/scripts/main.lua
@@ -31,7 +31,9 @@ function on_depot_broken(map_data, depot_id, depot)
 			if train.use_any_depot then
 				local e = get_any_train_entity(train.entity)
 				if e then
-					local stops = e.force.get_train_stops({name = depot.entity_stop.backer_name, surface = e.surface})
+					--local stops = e.force.get_train_stops({name = depot.entity_stop.backer_name, surface = e.surface})
+					local stops = game.train_manager.get_train_stops({station_name = depot.entity_stop.backer_name, force = e.force})
+					--game.print(serpent.block(stops))
 					for stop in rnext_consume, stops do
 						local new_depot_id = stop.unit_number
 						if new_depot_id ~= depot_id and map_data.depots[new_depot_id] then


### PR DESCRIPTION
Fixes bug report 

Error while running event cybersyn::on_pre_player_mined_item (ID 11)
LuaForce doesn't contain key get_train_stops.

https://discord.com/channels/1058170227000606811/1298642395960967258/1298642395960967258