### PR TITLE
Fix duplicate version entry in changelog

### DIFF
--- a/cybersyn/changelog.txt
+++ b/cybersyn/changelog.txt
@@ -1,16 +1,13 @@
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.6
-  Bugfixes:
-    - fix crash when cybersyn combinator is missing internal data during update
-    - fix for 2.0 migration can produce invalid LuaTrains
-  Translation:
-    - Russian language update
----------------------------------------------------------------------------------------------------
-Version: 2.0.6
   Changes:
     - support for Space Age Quality
   Bugfixes:
     - Fix close button for combinator
+    - fix crash when cybersyn combinator is missing internal data during update
+    - fix for 2.0 migration can produce invalid LuaTrains
+  Translation:
+    - Russian language update
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.5
   Bugfixes:


### PR DESCRIPTION
Merges the two duplicates into one entry for version 2.0.6.

The changelog format does not allow for two entries with the same version number: https://wiki.factorio.com/Tutorial:Mod_changelog_format#Version