### PR TITLE
Removed trains need cleanup in available_trains

### DIFF
--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -524,6 +524,11 @@ local function tick_dispatch(map_data, mod_settings)
 			if trains then
 				for train_id, _ in pairs(trains) do
 					local train = map_data.trains[train_id]
+					if not train then
+						-- removed train needs cleanup in available_trains
+						trains[train_id] = nil
+						goto train_continue
+					end
 
 					-- Check if train is on same Cybersyn network.
 					local train_flag = get_network_mask(train, network_name)


### PR DESCRIPTION
This happens when a mod that provides custom carriages is removed and those carriages where part of trains under Cybersyn's control. `MapData.trains` already gets cleaned but `MapData.available_trains` isn't. `available_trains` already gets looped over in `tick_dispatch`, so I think that's a good place to do lazy cleanup. This fixes

```
Error while running event cybersyn::on_nth_tick(2)
__cybersyn__/scripts/factorio-api.lua:111: attempt to index local 'e' (a nil value)
stack traceback:
	__cybersyn__/scripts/factorio-api.lua:111: in function 'get_network_mask'
	__cybersyn__/scripts/central-planning.lua:489: in function 'tick_dispatch'
	__cybersyn__/scripts/central-planning.lua:906: in function 'tick'
	__cybersyn__/scripts/main.lua:894: in function <__cybersyn__/scripts/main.lua:893>
```