### PR TITLE
fix: Fix detection of `loader-1x1` along tracks.

### DIFF
--- a/cybersyn/scripts/main.lua
+++ b/cybersyn/scripts/main.lua
@@ -654,6 +654,7 @@ local function on_built(event)
 	elseif entity.type == "inserter" then
 		update_stop_from_inserter(storage, entity)
 	elseif entity.type == "loader-1x1" then
+		-- NOTE: only 1x1 loaders supported here.
 		update_stop_from_loader(storage, entity)
 	elseif entity.type == "pump" then
 		update_stop_from_pump(storage, entity)
@@ -672,6 +673,7 @@ local function on_broken(event)
 	elseif entity.type == "inserter" then
 		update_stop_from_inserter(storage, entity, entity)
 	elseif entity.type == "loader-1x1" then
+		-- NOTE: only 1x1 loaders supported here.
 		update_stop_from_loader(storage, entity, entity)
 	elseif entity.type == "pump" then
 		update_stop_from_pump(storage, entity, entity)


### PR DESCRIPTION
Fixes an issue discussed in Discord re: loaders not being detected properly at train stops.

- Separated 1x1 and 1x2 loader detection.

- Correctly detect when a 1x1 loader built or destroyed would impact a stop.

- Correctly detect whether 1x1 loaders alongside tracks can load or unload cars for allow-list.

(NOTE: There is partial implementation support for 1x2 loaders in the 1.1 version of Cybersyn. It wasn't and still isn't working right. Someone will need to do a separate PR on that as I am not set up to test 1x2 loaders.)