### PR TITLE
feat: Warnings and fixes for issues caused by Factorio priority.

### DIFF
--- a/cybersyn/control.lua
+++ b/cybersyn/control.lua
@@ -1,5 +1,6 @@
 --By Mami
 require("scripts.constants")
+require("scripts.commands")
 require("scripts.global")
 require("scripts.lib")
 require("scripts.factorio-api")

--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -71,6 +71,7 @@ missing-train=Could not find any train on the correct network to make a delivery
 no-train-has-capacity=Could not find a train with enough cargo capacity to make a delivery from __2__ to __1__
 no-train-matches-r-layout=Could not find a train on the allow-list of __1__ to make a delivery
 no-train-matches-p-layout=Could not find a train on the allow-list of __2__ to make a delivery to __1__
+arrived-station-non-default-priority=A train managed by Project Cybersyn has arrived at a station with a Factorio priority different from the default of 50. Due to limitations of the Factorio API, this is NOT supported and WILL cause wrong deliveries. ALL stations on the train network must have priority 50.
 
 [cybersyn-gui]
 combinator-title=Cybernetic combinator

--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -72,6 +72,7 @@ no-train-has-capacity=Could not find a train with enough cargo capacity to make 
 no-train-matches-r-layout=Could not find a train on the allow-list of __1__ to make a delivery
 no-train-matches-p-layout=Could not find a train on the allow-list of __2__ to make a delivery to __1__
 station-non-default-priority=Train misdirected by Factorio priority at this station. Using non-default Factorio priority with Project Cybersyn WILL cause incorrect deliveries. You can fix problematic stations with /cybersyn-fix-priorities.
+fix-priorities-command-help=Resets the priority of problematic train stops back to 50
 
 [cybersyn-gui]
 combinator-title=Cybernetic combinator

--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -71,7 +71,7 @@ missing-train=Could not find any train on the correct network to make a delivery
 no-train-has-capacity=Could not find a train with enough cargo capacity to make a delivery from __2__ to __1__
 no-train-matches-r-layout=Could not find a train on the allow-list of __1__ to make a delivery
 no-train-matches-p-layout=Could not find a train on the allow-list of __2__ to make a delivery to __1__
-arrived-station-non-default-priority=A train managed by Project Cybersyn has arrived at a station with a Factorio priority different from the default of 50. Due to limitations of the Factorio API, this is NOT supported and WILL cause wrong deliveries. ALL stations on the train network must have priority 50.
+station-non-default-priority=Train misdirected by Factorio priority at this station. Using non-default Factorio priority with Project Cybersyn WILL cause incorrect deliveries. You can fix problematic stations with /cybersyn-fix-priorities.
 
 [cybersyn-gui]
 combinator-title=Cybernetic combinator

--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -73,6 +73,7 @@ no-train-matches-r-layout=Could not find a train on the allow-list of __1__ to m
 no-train-matches-p-layout=Could not find a train on the allow-list of __2__ to make a delivery to __1__
 station-non-default-priority=Train misdirected by Factorio priority at this station. Using non-default Factorio priority with Project Cybersyn WILL cause incorrect deliveries. You can fix problematic stations with /cybersyn-fix-priorities.
 fix-priorities-command-help=Resets the priority of problematic train stops back to 50
+find-priorities-command-help=Locates train stops with priority different from 50. These will cause misdirected trains.
 
 [cybersyn-gui]
 combinator-title=Cybernetic combinator

--- a/cybersyn/scripts/commands.lua
+++ b/cybersyn/scripts/commands.lua
@@ -1,0 +1,24 @@
+local function fix_priorities_command()
+    -- don't depend on any 'storage' data for a repair command
+
+    -- only stops with the same name as a cybersyn stop need to have their priorities reset
+    local cybersyn_names = {}
+    for _,s in pairs(game.surfaces) do
+        for _,ts in pairs(s.find_entities_filtered {name="train-stop"}) do
+            if next(s.find_entities_filtered {name="cybersyn-combinator", position=ts.position, radius=3}) then
+                cybersyn_names[ts.backer_name] = true
+            end
+        end
+    end
+
+    for _,s in pairs(game.surfaces) do
+        for _,ts in pairs(s.find_entities_filtered {name="train-stop"}) do
+            if ts.train_stop_priority ~= 50 and cybersyn_names[ts.backer_name] then
+                ts.train_stop_priority = 50
+                game.print("Reset [train-stop="..ts.unit_number.."] to priority 50")
+            end
+        end
+    end
+end
+
+commands.add_command("cybersyn-fix-priorities", {"cybersyn-messages.fix-priorities-command-help"}, fix_priorities_command)

--- a/cybersyn/scripts/commands.lua
+++ b/cybersyn/scripts/commands.lua
@@ -1,24 +1,47 @@
+--- Find the names of all Cybersyn stations in the game.
+---@return {[string]: true} cybersyn_names Hash of all Cybersyn station names mapped to `true`
+local function find_cybersyn_station_names()
+	local cybersyn_names = {}
+	for _,s in pairs(game.surfaces) do
+		for _,ts in pairs(s.find_entities_filtered {name="train-stop"}) do
+			if next(s.find_entities_filtered {name="cybersyn-combinator", position=ts.position, radius=3}) then
+				cybersyn_names[ts.backer_name] = true
+			end
+		end
+	end
+	return cybersyn_names
+end
+
+--- Run a function on each stop with non-default priority
+---@param callback fun(train_stop: LuaEntity) 
+local function for_each_stop_with_invalid_priority(callback)
+	-- Priority is only problematic when a station is named the same as a
+	-- Cybersyn station.
+	local cybersyn_names = find_cybersyn_station_names()
+	for _,s in pairs(game.surfaces) do
+		for _,ts in pairs(s.find_entities_filtered {name="train-stop"}) do
+			if ts.train_stop_priority ~= 50 and cybersyn_names[ts.backer_name] then
+				callback(ts)
+			end
+		end
+	end
+end
+
 local function fix_priorities_command()
-    -- don't depend on any 'storage' data for a repair command
+	-- don't depend on any 'storage' data for a repair command
 
-    -- only stops with the same name as a cybersyn stop need to have their priorities reset
-    local cybersyn_names = {}
-    for _,s in pairs(game.surfaces) do
-        for _,ts in pairs(s.find_entities_filtered {name="train-stop"}) do
-            if next(s.find_entities_filtered {name="cybersyn-combinator", position=ts.position, radius=3}) then
-                cybersyn_names[ts.backer_name] = true
-            end
-        end
-    end
+	for_each_stop_with_invalid_priority(function(ts)
+		ts.train_stop_priority = 50
+		game.print("Reset [train-stop="..ts.unit_number.."] to priority 50")
+	end)
+end
 
-    for _,s in pairs(game.surfaces) do
-        for _,ts in pairs(s.find_entities_filtered {name="train-stop"}) do
-            if ts.train_stop_priority ~= 50 and cybersyn_names[ts.backer_name] then
-                ts.train_stop_priority = 50
-                game.print("Reset [train-stop="..ts.unit_number.."] to priority 50")
-            end
-        end
-    end
+local function find_priorities_command()
+	for_each_stop_with_invalid_priority(function(ts)
+		game.print("[train-stop="..ts.unit_number.."] has priority "..ts.train_stop_priority .. " and will cause Project Cybersyn trains to be misdirected.")
+	end)
 end
 
 commands.add_command("cybersyn-fix-priorities", {"cybersyn-messages.fix-priorities-command-help"}, fix_priorities_command)
+
+commands.add_command("cybersyn-find-priorities", {"cybersyn-messages.find-priorities-command-help"}, find_priorities_command)

--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -766,6 +766,23 @@ local function send_alert_for_train(train, icon, message)
 		end
 	end
 end
+
+--- Send an alert about a particular train station.
+---@param station LuaEntity Must be a train stop.
+---@param icon {}
+---@param message string
+local function send_alert_for_station(station, icon, message)
+	for _, player in pairs(station.force.players) do
+		player.add_custom_alert(
+		station,
+		icon,
+		{message},
+		true)
+		player.play_sound({path = ALERT_SOUND})
+	end
+end
+
+
 local send_alert_about_missing_train_icon = {name = MISSING_TRAIN_NAME, type = "fluid"}
 ---@param r_stop LuaEntity
 ---@param p_stop LuaEntity
@@ -872,6 +889,13 @@ function send_alert_cannot_path_between_surfaces(map_data, train)
 	send_alert_sounds(train)
 	map_data.active_alerts = map_data.active_alerts or {}
 	map_data.active_alerts[train.id] = {train, 7, map_data.total_ticks}
+end
+
+--- Alert user when a Cybersyn train arrives at a station with non-default
+--- vanilla priority. This usually means a missed delivery.
+---@param station LuaEntity Must be a train stop.
+function send_alert_arrived_station_non_default_priority(station)
+	send_alert_for_station(station, send_lost_train_alert_icon, "cybersyn-messages.arrived-station-non-default-priority")
 end
 
 ---@param train LuaTrain

--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -894,8 +894,8 @@ end
 --- Alert user when a Cybersyn train arrives at a station with non-default
 --- vanilla priority. This usually means a missed delivery.
 ---@param station LuaEntity Must be a train stop.
-function send_alert_arrived_station_non_default_priority(station)
-	send_alert_for_station(station, send_lost_train_alert_icon, "cybersyn-messages.arrived-station-non-default-priority")
+function send_alert_station_non_default_priority(station)
+	send_alert_for_station(station, send_lost_train_alert_icon, "cybersyn-messages.station-non-default-priority")
 end
 
 ---@param train LuaTrain

--- a/cybersyn/scripts/train-events.lua
+++ b/cybersyn/scripts/train-events.lua
@@ -441,6 +441,7 @@ function on_train_changed(event)
 	if train_e.state == defines.train_state.wait_station then
 		local stop = train_e.station
 		if stop and stop.valid and stop.name == "train-stop" then
+			-- Arrived at explicitly named stop
 			local id = stop.unit_number--[[@as uint]]
 			local depot = map_data.depots[id]
 			if depot then
@@ -450,7 +451,20 @@ function on_train_changed(event)
 					on_depot_broken(map_data, id, depot)
 				end
 			end
+
+			-- Check for invalid usage of priority
+			if stop.train_stop_priority ~= 50 then
+				-- If train under control of Cybersyn arrives at non default priority station, alert user.
+				local train = map_data.trains[train_id]
+				if train then
+					send_alert_arrived_station_non_default_priority(stop)
+				end
+			end
 		else
+			-- Arrived at stop specified by coordinates. This event fires
+			-- slightly before the train arrives at the real target stop.
+			-- NOTE: if Factorio API ever allows sending trains to particular
+			-- stops, this will have to be changed.
 			local train = map_data.trains[train_id]
 			if train then
 				local schedule = train_e.schedule

--- a/cybersyn/scripts/train-events.lua
+++ b/cybersyn/scripts/train-events.lua
@@ -457,7 +457,7 @@ function on_train_changed(event)
 				-- If train under control of Cybersyn arrives at non default priority station, alert user.
 				local train = map_data.trains[train_id]
 				if train then
-					send_alert_arrived_station_non_default_priority(stop)
+					send_alert_station_non_default_priority(stop)
 				end
 			end
 		else
@@ -503,6 +503,18 @@ function on_train_changed(event)
 		if path and path.total_distance > 4 then
 			local train = map_data.trains[train_id]
 			if train then
+				-- Check if train has been misdirected along a long rail path due to
+				-- the priority of the station at the end.
+				local last_rail = path.rails[#path.rails]
+				local to_stop = (last_rail and last_rail.valid) and (last_rail.get_rail_segment_stop(defines.rail_direction.front) or last_rail.get_rail_segment_stop(defines.rail_direction.back))
+				if to_stop and to_stop.train_stop_priority ~= 50 then
+					send_alert_station_non_default_priority(to_stop)
+					-- Fallthrough: still executing normal cybersyn behavior here even
+					-- though it will probably cause a wrong delivery. (This may be
+					-- a case where we want to lock the train or give it an invalid
+					-- schedule as is done elsewhere in the code.)
+				end
+				
 				on_train_leaves_stop(map_data, mod_settings, train_id, train)
 			end
 		end


### PR DESCRIPTION
- Added alerts to problematic stations in certain code paths where we can predict priority will interfere with deliveries.
- Added `/cybersyn-find-priorities` and `/cybersyn-fix-priorities` slash commands which will list (and automatically fix, respectively) stations with priorities that will interfere with Cybersyn.