### PR TITLE
Expand the problem detection command

### DIFF
--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -77,20 +77,17 @@ find-problems-command-help=Locates train stops that cause problems in the Cybers
 
 [cybersyn-problems]
 message-wrapper=__1__ __2__
-
 double-station=has more than one Cybersyn combinator in station mode.
 double-station-control=has more than one Cybersyn combinator in station control mode.
 double-depot=has more than one Cybersyn combinator in depot mode.
 double-refueler=has more than one Cybersyn combinator in refueler mode.
-
 station-and-depot=cannot be a requester/provider and a depot.
 station-and-refueler=cannot be a requester/provider and a refueler.
 depot-and-refueler=cannot be a depot and a refueler.
-
 non-default-priority=uses priorities which will misdirect trains controlled by Cybersyn. Reset to 50 and use Cybersyn's [virtual-signal=cybersyn-priority] if appropriate.
 priority-was-reset=was reset to priority 50.
 name-overlap-with-depot=has the same name as a Cybersyn depot. This will lead to ghost deliveries because trains arriving here from a previous delivery will not reset their delivery schedule.
-name-overlap-with-refueler=has the same name as a Cybersyn refueler. TODO: Is this a problem?
+name-overlap-with-refueler=has the same name as a Cybersyn refueler.
 
 [cybersyn-gui]
 combinator-title=Cybernetic combinator

--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -77,7 +77,7 @@ find-problems-command-help=Locates train stops that cause problems in the Cybers
 
 [cybersyn-problems]
 message-wrapper=__1__ __2__
-no-problems-found=The [img=item/construction-robot] bots ran their checklist on all your Cybersyn stations and came up empty [img=virtual-signal/signal-check].
+no-problems-found=The [img=item/construction-robot] bots ran their checklist on all your Cybersyn stations and have nothing to report [img=virtual-signal/signal-check].
 double-station=has more than one Cybersyn combinator in station mode.
 double-station-control=has more than one Cybersyn combinator in station control mode.
 double-depot=has more than one Cybersyn combinator in depot mode.

--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -77,6 +77,7 @@ find-problems-command-help=Locates train stops that cause problems in the Cybers
 
 [cybersyn-problems]
 message-wrapper=__1__ __2__
+no-problems-found=[img=virtual-signal/signal-check] None of the known problems are present in your Cybersyn network.
 double-station=has more than one Cybersyn combinator in station mode.
 double-station-control=has more than one Cybersyn combinator in station control mode.
 double-depot=has more than one Cybersyn combinator in depot mode.

--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -73,7 +73,24 @@ no-train-matches-r-layout=Could not find a train on the allow-list of __1__ to m
 no-train-matches-p-layout=Could not find a train on the allow-list of __2__ to make a delivery to __1__
 station-non-default-priority=Train misdirected by Factorio priority at this station. Using non-default Factorio priority with Project Cybersyn WILL cause incorrect deliveries. You can fix problematic stations with /cybersyn-fix-priorities.
 fix-priorities-command-help=Resets the priority of problematic train stops back to 50
-find-priorities-command-help=Locates train stops with priority different from 50. These will cause misdirected trains.
+find-problems-command-help=Locates train stops that cause problems in the Cybersyn network
+
+[cybersyn-problems]
+message-wrapper=__1__ __2__
+
+double-station=has more than one Cybersyn combinator in station mode.
+double-station-control=has more than one Cybersyn combinator in station control mode.
+double-depot=has more than one Cybersyn combinator in depot mode.
+double-refueler=has more than one Cybersyn combinator in refueler mode.
+
+station-and-depot=cannot be a requester/provider and a depot.
+station-and-refueler=cannot be a requester/provider and a refueler.
+depot-and-refueler=cannot be a depot and a refueler.
+
+non-default-priority=uses priorities which will misdirect trains controlled by Cybersyn. Reset to 50 and use Cybersyn's [virtual-signal=cybersyn-priority] if appropriate.
+priority-was-reset=was reset to priority 50.
+name-overlap-with-depot=has the same name as a Cybersyn depot. This will lead to ghost deliveries because trains arriving here from a previous delivery will not reset their delivery schedule.
+name-overlap-with-refueler=has the same name as a Cybersyn refueler. TODO: Is this a problem?
 
 [cybersyn-gui]
 combinator-title=Cybernetic combinator

--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -77,7 +77,7 @@ find-problems-command-help=Locates train stops that cause problems in the Cybers
 
 [cybersyn-problems]
 message-wrapper=__1__ __2__
-no-problems-found=[img=virtual-signal/signal-check] None of the known problems are present in your Cybersyn network.
+no-problems-found=The [img=item/logistic-robot] bots ran their checklist on all your Cybersyn stations and came up empty [img=virtual-signal/signal-check].
 double-station=has more than one Cybersyn combinator in station mode.
 double-station-control=has more than one Cybersyn combinator in station control mode.
 double-depot=has more than one Cybersyn combinator in depot mode.

--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -77,7 +77,7 @@ find-problems-command-help=Locates train stops that cause problems in the Cybers
 
 [cybersyn-problems]
 message-wrapper=__1__ __2__
-no-problems-found=The [img=item/logistic-robot] bots ran their checklist on all your Cybersyn stations and came up empty [img=virtual-signal/signal-check].
+no-problems-found=The [img=item/construction-robot] bots ran their checklist on all your Cybersyn stations and came up empty [img=virtual-signal/signal-check].
 double-station=has more than one Cybersyn combinator in station mode.
 double-station-control=has more than one Cybersyn combinator in station control mode.
 double-depot=has more than one Cybersyn combinator in depot mode.

--- a/cybersyn/scripts/commands.lua
+++ b/cybersyn/scripts/commands.lua
@@ -2,7 +2,8 @@
 --- @param stop LuaEntity
 --- @param message LocalisedString
 local function report_print(stop, message)
-	local stop_info = string.format("[train-stop=%d] [gps=%d,%d,%s]", stop.unit_number, stop.position.x, stop.position.y, stop.surface.name)
+	-- local stop_info = string.format("[train-stop=%d] [gps=%d,%d,%s]", stop.unit_number, stop.position.x, stop.position.y, stop.surface.name)
+	local stop_info = string.format("[train-stop=%d]", stop.unit_number)
 	game.print({"cybersyn-problems.message-wrapper", stop_info, message})
 end
 

--- a/cybersyn/scripts/commands.lua
+++ b/cybersyn/scripts/commands.lua
@@ -1,27 +1,88 @@
+
+--- @param stop LuaEntity
+--- @param message LocalisedString
+local function report_print(stop, message)
+	local stop_info = string.format("[train-stop=%d] [gps=%d,%d,%s]", stop.unit_number, stop.position.x, stop.position.y, stop.surface.name)
+	game.print({"cybersyn-problems.message-wrapper", stop_info, message})
+end
+
+local function report_noop(stop, message)
+end
+
 --- Find the names of all Cybersyn stations in the game.
----@return {[string]: true} cybersyn_names Hash of all Cybersyn station names mapped to `true`
-local function find_cybersyn_station_names()
-	local cybersyn_names = {}
+--- @param report function(LuaEntity, LocalisedString)
+--- 
+--- @return {[integer]: string} station_types maps from train-stop unit_number to cybersyn station type (MODE_PRIMARY_IO | MODE_DEPOT | MODE_REFUELER | nil)
+--- @return {[string]: boolean} station_names set of station names (requester/provider)
+--- @return {[string]: boolean} depot_names set of depot names
+--- @return {[string]: boolean} refueler_names set of refueler names
+local function check_single_stations_and_collect_data(report)
+	local station_names = {}
+	local depot_names = {}
+	local refueler_names = {}
+	local station_types = {}
+
 	for _,s in pairs(game.surfaces) do
 		for _,ts in pairs(s.find_entities_filtered {name="train-stop"}) do
-			if next(s.find_entities_filtered {name="cybersyn-combinator", position=ts.position, radius=3}) then
-				cybersyn_names[ts.backer_name] = true
+			local comb_1 = nil
+			local comb_2 = nil
+			local depot  = nil
+			local refuel = nil
+
+			for _,c in pairs(s.find_entities_filtered {name="cybersyn-combinator", position=ts.position, radius=3}) do
+				local op = c.get_control_behavior()
+				op = op and op.parameters.operation
+
+				if op == MODE_PRIMARY_IO or op == MODE_PRIMARY_IO_ACTIVE or op == MODE_PRIMARY_IO_FAILED_REQUEST then
+					if not comb_1 then comb_1 = c else report(ts, {"cybersyn-problems.double-station"}) end
+				elseif op == MODE_SECONDARY_IO then
+					if not comb_2 then comb_2 = c else report(ts, {"cybersyn-problems.double-station-control"}) end
+				elseif op == MODE_DEPOT then
+					if not depot  then depot  = c else report(ts, {"cybersyn-problems.double-depot"}) end
+				elseif op == MODE_REFUELER then
+					if not refuel then refuel = c else report(ts, {"cybersyn-problems.double-refueler"}) end
+				end
+			end
+
+			if comb_1 and depot  then report(ts, {"cybersyn-problems.station-and-depot"}) end
+			if comb_1 and refuel then report(ts, {"cybersyn-problems.station-and-refueler"}) end
+			if depot  and refuel then report(ts, {"cybersyn-problems.depot-and-refueler"}) end
+
+			if comb_1 then -- station mode takes precedence
+				station_types [ts.unit_number] = MODE_PRIMARY_IO
+				station_names [ts.backer_name] = true
+			elseif depot then
+				station_types [ts.unit_number] = MODE_DEPOT
+				depot_names   [ts.backer_name] = true
+			elseif refuel then
+				station_types [ts.unit_number] = MODE_REFUELER
+				refueler_names[ts.backer_name] = true
 			end
 		end
 	end
-	return cybersyn_names
+
+	return station_types, station_names, depot_names, refueler_names
 end
 
---- Run a function on each stop with non-default priority
----@param callback fun(train_stop: LuaEntity) 
-local function for_each_stop_with_invalid_priority(callback)
-	-- Priority is only problematic when a station is named the same as a
-	-- Cybersyn station.
-	local cybersyn_names = find_cybersyn_station_names()
+--- @param report function(LuaEntity, LocalisedString)
+local function find_problems(report)
+	local types, stations, depots, refuelers = check_single_stations_and_collect_data(report)
+
+	-- global checks 
 	for _,s in pairs(game.surfaces) do
 		for _,ts in pairs(s.find_entities_filtered {name="train-stop"}) do
-			if ts.train_stop_priority ~= 50 and cybersyn_names[ts.backer_name] then
-				callback(ts)
+			-- priority is only problematic when a station is named the same as a Cybersyn requester/provider
+			local name = ts.backer_name
+			if ts.train_stop_priority ~= 50 and (stations[name] or depots[name] or refuelers[name]) then
+				report(ts, {"cybersyn-problems.non-default-priority"})
+			end
+
+			local type = types[ts.unit_number]
+			if type ~= MODE_DEPOT and depots[ts.backer_name] then
+				report(ts, {"cybersyn-problems.name-overlap-with-depot"})
+			end
+			if type ~= MODE_REFUELER and refuelers[ts.backer_name] then
+				report(ts, {"cybersyn-problems.name-overlap-with-refueler"})
 			end
 		end
 	end
@@ -29,19 +90,17 @@ end
 
 local function fix_priorities_command()
 	-- don't depend on any 'storage' data for a repair command
+	local _, stations, depots, refuelers = check_single_stations_and_collect_data(report_noop)
 
-	for_each_stop_with_invalid_priority(function(ts)
-		ts.train_stop_priority = 50
-		game.print("Reset [train-stop="..ts.unit_number.."] to priority 50")
-	end)
+	for _,s in pairs(game.surfaces) do
+		for _,ts in pairs(s.find_entities_filtered {name="train-stop"}) do
+			local name = ts.backer_name
+			if ts.train_stop_priority ~= 50 and (stations[name] or depots[name] or refuelers[name]) then
+				report_print(ts, {"cybersyn-problems.priority-was-reset"})
+			end
+		end
+	end
 end
 
-local function find_priorities_command()
-	for_each_stop_with_invalid_priority(function(ts)
-		game.print("[train-stop="..ts.unit_number.."] has priority "..ts.train_stop_priority .. " and will cause Project Cybersyn trains to be misdirected.")
-	end)
-end
-
+commands.add_command("cybersyn-find-problems", {"cybersyn-messages.find-problems-command-help"}, function() find_problems(report_print) end)
 commands.add_command("cybersyn-fix-priorities", {"cybersyn-messages.fix-priorities-command-help"}, fix_priorities_command)
-
-commands.add_command("cybersyn-find-priorities", {"cybersyn-messages.find-priorities-command-help"}, find_priorities_command)

--- a/cybersyn/scripts/commands.lua
+++ b/cybersyn/scripts/commands.lua
@@ -82,9 +82,11 @@ local function find_problems(report)
 			if type ~= MODE_DEPOT and depots[ts.backer_name] then
 				report(ts, {"cybersyn-problems.name-overlap-with-depot"})
 			end
-			if type ~= MODE_REFUELER and refuelers[ts.backer_name] then
-				report(ts, {"cybersyn-problems.name-overlap-with-refueler"})
-			end
+
+			-- TODO decide if this is actually a problem
+			-- if type ~= MODE_REFUELER and refuelers[ts.backer_name] then
+			--	report(ts, {"cybersyn-problems.name-overlap-with-refueler"})
+			-- end
 		end
 	end
 end


### PR DESCRIPTION
`/cybersyn-find-priorities` becomes `/cybersyn-find-problems` with additional inspections.

So far surfaces are not handled separately and it is debatable if they should be.