### PR TITLE
feat: Color all locomotives of a train by next stop if set by user

### DIFF
--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -185,7 +185,7 @@ function create_delivery(map_data, r_station_id, p_station_id, train_id, manifes
 		r_station.display_state = 1
 		update_display(map_data, r_station)
 
-		color_train_by_stop(train, p_station.entity_stop)
+		color_train_by_stop(train.entity, p_station.entity_stop)
 		interface_raise_train_status_changed(train_id, old_status, STATUS_TO_P)
 	else
 		interface_raise_train_dispatch_failed(train_id)

--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -185,6 +185,7 @@ function create_delivery(map_data, r_station_id, p_station_id, train_id, manifes
 		r_station.display_state = 1
 		update_display(map_data, r_station)
 
+		color_train_by_stop(train, p_station.entity_stop)
 		interface_raise_train_status_changed(train_id, old_status, STATUS_TO_P)
 	else
 		interface_raise_train_dispatch_failed(train_id)

--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -116,15 +116,15 @@ end
 
 --- Sets colors of all locomotives of the train to the color of the given station.
 --- Respects the copy_color_from_train_stop user setting.
----@param train Train
+---@param train LuaTrain
 ---@param station LuaEntity
 function color_train_by_stop(train, station)
-	for _, locomotive in ipairs(train.entity.locomotives.front_movers) do
+	for _, locomotive in ipairs(train.locomotives.front_movers) do
 		if locomotive.copy_color_from_train_stop then
 			locomotive.color = station.color
 		end
 	end
-	for _, locomotive in ipairs(train.entity.locomotives.back_movers) do
+	for _, locomotive in ipairs(train.locomotives.back_movers) do
 		if locomotive.copy_color_from_train_stop then
 			locomotive.color = station.color
 		end

--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -114,6 +114,24 @@ function get_network_mask(e, network_name)
 end
 
 
+--- Sets colors of all locomotives of the train to the color of the given station.
+--- Respects the copy_color_from_train_stop user setting.
+---@param train Train
+---@param station LuaEntity
+function color_train_by_stop(train, station)
+	for _, locomotive in ipairs(train.entity.locomotives.front_movers) do
+		if locomotive.copy_color_from_train_stop then
+			locomotive.color = station.color
+		end
+	end
+	for _, locomotive in ipairs(train.entity.locomotives.back_movers) do
+		if locomotive.copy_color_from_train_stop then
+			locomotive.color = station.color
+		end
+	end
+end
+
+
 ------------------------------------------------------------------------------
 --[[train schedules]]--
 ------------------------------------------------------------------------------

--- a/cybersyn/scripts/train-events.lua
+++ b/cybersyn/scripts/train-events.lua
@@ -267,6 +267,7 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 				end
 			end
 		end
+		color_train_by_stop(train, map_data.stations[train.r_station_id].entity_stop)
 		interface_raise_train_status_changed(train_id, STATUS_P, STATUS_TO_R)
 	elseif train.status == STATUS_R then
 		local station = map_data.stations[train.r_station_id]
@@ -305,6 +306,7 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 			if not train.disable_bypass then
 				train.status = STATUS_TO_D_BYPASS
 				add_available_train(map_data, train_id, train)
+				color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
 				interface_raise_train_status_changed(train_id, STATUS_R, STATUS_TO_D_BYPASS)
 				return
 			end
@@ -356,6 +358,7 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 							train.status = STATUS_TO_F
 							train.refueler_id = best_refueler_id
 							refueler.trains_total = refueler.trains_total + 1
+							color_train_by_stop(train, map_data.refuelers[train.refueler_id].entity_stop)
 							interface_raise_train_status_changed(train_id, STATUS_R, STATUS_TO_F)
 							return
 						end
@@ -365,6 +368,7 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 		end
 		--the train has not qualified for depot bypass nor refueling
 		train.status = STATUS_TO_D
+		color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
 		interface_raise_train_status_changed(train_id, STATUS_R, STATUS_TO_D)
 	elseif train.status == STATUS_F then
 		local refueler = map_data.refuelers[train.refueler_id]
@@ -380,6 +384,7 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 		else
 			train.status = STATUS_TO_D
 		end
+		color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
 		interface_raise_train_status_changed(train_id, STATUS_F, train.status)
 	elseif train.status == STATUS_D then
 		--The train is leaving the depot without a manifest, the player likely intervened

--- a/cybersyn/scripts/train-events.lua
+++ b/cybersyn/scripts/train-events.lua
@@ -267,7 +267,7 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 				end
 			end
 		end
-		color_train_by_stop(train, map_data.stations[train.r_station_id].entity_stop)
+		color_train_by_stop(train.entity, map_data.stations[train.r_station_id].entity_stop)
 		interface_raise_train_status_changed(train_id, STATUS_P, STATUS_TO_R)
 	elseif train.status == STATUS_R then
 		local station = map_data.stations[train.r_station_id]
@@ -308,7 +308,7 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 				add_available_train(map_data, train_id, train)
 				if not train.use_any_depot then
 					-- train using same depot, coord. station was inserted -> we need to color
-					color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
+					color_train_by_stop(train.entity, map_data.depots[train.depot_id].entity_stop)
 				end
 				interface_raise_train_status_changed(train_id, STATUS_R, STATUS_TO_D_BYPASS)
 				return
@@ -361,7 +361,7 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 							train.status = STATUS_TO_F
 							train.refueler_id = best_refueler_id
 							refueler.trains_total = refueler.trains_total + 1
-							color_train_by_stop(train, map_data.refuelers[train.refueler_id].entity_stop)
+							color_train_by_stop(train.entity, map_data.refuelers[train.refueler_id].entity_stop)
 							interface_raise_train_status_changed(train_id, STATUS_R, STATUS_TO_F)
 							return
 						end
@@ -373,7 +373,7 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 		train.status = STATUS_TO_D
 		if not train.use_any_depot then
 			-- train using same depot, coord. station was inserted -> we need to color
-			color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
+			color_train_by_stop(train.entity, map_data.depots[train.depot_id].entity_stop)
 		end
 		interface_raise_train_status_changed(train_id, STATUS_R, STATUS_TO_D)
 	elseif train.status == STATUS_F then
@@ -392,7 +392,7 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 		end
 		if not train.use_any_depot then
 			-- train using same depot, coord. station was inserted -> we need to color
-			color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
+			color_train_by_stop(train.entity, map_data.depots[train.depot_id].entity_stop)
 		end
 		interface_raise_train_status_changed(train_id, STATUS_F, train.status)
 	elseif train.status == STATUS_D then

--- a/cybersyn/scripts/train-events.lua
+++ b/cybersyn/scripts/train-events.lua
@@ -306,7 +306,10 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 			if not train.disable_bypass then
 				train.status = STATUS_TO_D_BYPASS
 				add_available_train(map_data, train_id, train)
-				color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
+				if not train.use_any_depot then
+					-- train using same depot, coord. station was inserted -> we need to color
+					color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
+				end
 				interface_raise_train_status_changed(train_id, STATUS_R, STATUS_TO_D_BYPASS)
 				return
 			end
@@ -368,7 +371,10 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 		end
 		--the train has not qualified for depot bypass nor refueling
 		train.status = STATUS_TO_D
-		color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
+		if not train.use_any_depot then
+			-- train using same depot, coord. station was inserted -> we need to color
+			color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
+		end
 		interface_raise_train_status_changed(train_id, STATUS_R, STATUS_TO_D)
 	elseif train.status == STATUS_F then
 		local refueler = map_data.refuelers[train.refueler_id]
@@ -384,7 +390,10 @@ local function on_train_leaves_stop(map_data, mod_settings, train_id, train)
 		else
 			train.status = STATUS_TO_D
 		end
-		color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
+		if not train.use_any_depot then
+			-- train using same depot, coord. station was inserted -> we need to color
+			color_train_by_stop(train, map_data.depots[train.depot_id].entity_stop)
+		end
 		interface_raise_train_status_changed(train_id, STATUS_F, train.status)
 	elseif train.status == STATUS_D then
 		--The train is leaving the depot without a manifest, the player likely intervened


### PR DESCRIPTION
Due to the need of putting a coordinate stop before the actual stop in the train schedule, if used had the vanilla option to color the locomotive by the destination stop did not work. The color would only be applied when the train arrived (because of the coordinate stop).

This PR fixes that, coloring the locomotives when the train status gets changed on mod side. It respects the user setting for each locomotive.

This makes cybersyn work flawlessly with the vanilla feature of coloring trains by destination stop.

Edit: performance impact was not tested, though it should be almost zero, the train coloring code is called only once on the event of train leaving for the next stop.