### PR TITLE
feat: Support Global Variable Viewer mod if installed

### DIFF
--- a/cybersyn/control.lua
+++ b/cybersyn/control.lua
@@ -11,3 +11,7 @@ require("scripts.gui")
 require("scripts.migrations")
 require("scripts.main")
 require("scripts.remote-interface")
+
+-- Enable support for the Global Variable Viewer debugging mod, if it is
+-- installed.
+if script.active_mods["gvv"] then require("__gvv__.gvv")() end


### PR DESCRIPTION
Adds support for the Global Variable Viewer mod. This lets developers look into Cybersyn's internal state vector. There is no effect if GVV is not installed.