### PR TITLE
fix: Reduce opinionation of editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ quote_style = double
 # call_arg_parentheses = keep
 # continuation_indent = 4
 # max_line_length = 120
-trailing_table_separator = never
+trailing_table_separator = smart
 
 ## Whitespace options
 # space_around_table_field_list = true
@@ -30,12 +30,15 @@ space_inside_square_brackets = false
 space_around_table_append_operator = false
 ignore_spaces_inside_function_call = false
 # space_before_inline_comment = 1
+# space_after_comment_dash = false
 
 ## Operator whitespace
 # space_around_math_operator = true
 # space_after_comma = true
 # space_after_comma_in_for_statement = true
 # space_around_concat_operator = true
+# space_around_logical_operator = true
+# space_around_assign_operator = true
 
 ## Alignment
 # Many of these will be set to false since alignment does not play well with tab indentation
@@ -50,17 +53,19 @@ align_array_table = false
 ## Other indentation settings
 never_indent_before_if_condition = false
 never_indent_comment_on_if_branch = false
+keep_indents_on_empty_lines = false
+allow_non_indented_comments = true
 
 ## Line spacings
-line_space_after_if_statement = max(1)
-line_space_after_do_statement = max(1)
-line_space_after_while_statement = max(1)
-line_space_after_repeat_statement = max(1)
-line_space_after_for_statement = max(1)
-line_space_after_local_or_assign_statement = max(1)
-line_space_after_function_statement = fixed(1)
-line_space_after_expression_statement = max(1)
-line_space_after_comment = max(1)
+line_space_after_if_statement = max(2)
+line_space_after_do_statement = max(2)
+line_space_after_while_statement = max(2)
+line_space_after_repeat_statement = max(2)
+line_space_after_for_statement = max(2)
+line_space_after_local_or_assign_statement = max(2)
+line_space_after_function_statement = max(2)
+line_space_after_expression_statement = keep
+line_space_after_comment = keep
 
 ## Line breaks
 break_all_list_when_line_exceed = true
@@ -69,4 +74,4 @@ break_all_list_when_line_exceed = true
 ## "Preferences"
 ignore_space_after_colon = false
 # remove_call_expression_list_finish_comma = false
-end_statement_with_semicolon = replace_with_newline
+end_statement_with_semicolon = keep


### PR DESCRIPTION
The new editorconfig was a little too strict when combined with automatic code formatting in VSCode, resulting in very undesirable minification/whitespace removal. I loosened it a bit. After some testing, I believe submitting autoformatted code should be quite safe after this change.