### PR TITLE
Fix: crash in GUI manager when signal type was not fluid or item

### DIFF
--- a/cybersyn/scripts/gui/inventory.lua
+++ b/cybersyn/scripts/gui/inventory.lua
@@ -173,11 +173,7 @@ function inventory_tab.build(map_data, player_data)
   local i = 0
   for item_hash, count in pairs(inventory_provided) do
     item, quality = unhash_signal(item_hash)
-    local signal = {
-      type = prototypes.item[item] == nil and "fluid" or "item",
-      name=item,
-      quality=quality,
-    }
+    local signal = util.signalid_from_name(item, quality)
     i = i + 1
     provided_children[#provided_children+1] = {
       type = "choose-elem-button",
@@ -208,11 +204,7 @@ function inventory_tab.build(map_data, player_data)
   local i = 0
   for item_hash, count in pairs(inventory_requested) do
     item, quality = unhash_signal(item_hash)
-    local signal = {
-      type = prototypes.item[item] == nil and "fluid" or "item",
-      name=item,
-      quality=quality,
-    }
+    local signal = util.signalid_from_name(item, quality)
     i = i + 1
     requested_children[#requested_children+1] = {
       type = "choose-elem-button",
@@ -243,11 +235,7 @@ function inventory_tab.build(map_data, player_data)
   local i = 0
   for item_hash, count in pairs(inventory_in_transit) do
     item, quality = unhash_signal(item_hash)
-    local signal = {
-      type = prototypes.item[item] == nil and "fluid" or "item",
-      name=item,
-      quality=quality,
-    }
+    local signal = util.signalid_from_name(item, quality)
     i = i + 1
     in_transit_children[#in_transit_children+1] = {
       type = "choose-elem-button",

--- a/cybersyn/scripts/gui/util.lua
+++ b/cybersyn/scripts/gui/util.lua
@@ -65,7 +65,27 @@ function util.rich_text_from_signal(signal)
   return "[" .. type .. "=" .. signal.name .. ",quality=" .. quality .. "]"
 end
 
-
+--- Creates a SignalID structure from an item name and optional quality.
+---@param name string
+---@param quality string?
+---@return SignalID
+function util.signalid_from_name(name, quality)
+  ---@type SignalIDType
+  -- TODO is there a better way to get item type from name?
+  local signal_type = prototypes.item[name] ~= nil and "item" or
+                      prototypes.fluid[name] ~= nil and "fluid" or
+                      prototypes.virtual_signal[name] ~= nil and "virtual" or
+                      prototypes.entity[name] ~= nil and "entity" or
+                      prototypes.recipe[name] ~= nil and "recipe" or
+                      prototypes.space_location[name] ~= nil and "space-location" or
+                      prototypes.asteroid_chunk[name] ~= nil and "asteroid-chunk" or
+                      "quality"
+  return {
+    type = signal_type,
+    name = name,
+    quality = quality,
+  }
+end
 
 --- Updates a slot table based on the passed criteria.
 --- @param manifest Manifest?
@@ -178,11 +198,7 @@ function util.slot_table_build_from_deliveries(station)
 
   for item_hash, count in pairs(deliveries) do
     item, quality = unhash_signal(item_hash)
-    local signal = {
-      type = prototypes.item[item] == nil and "fluid" or "item",
-      name=item,
-      quality=quality,
-    }
+    local signal = util.signalid_from_name(item, quality)
 
     local color
     if count > 0 then


### PR DESCRIPTION
resolves bug report: https://discord.com/channels/1058170227000606811/1313466981709643797

Fixes a crash when a item displayed in the inventory tab was not of type 'item' or 'fluid'. Apparently this can happen in pyanodons.