### PR TITLE
feat: GUI - add localised item names into tooltips

### DIFF
--- a/cybersyn/scripts/gui/inventory.lua
+++ b/cybersyn/scripts/gui/inventory.lua
@@ -170,7 +170,7 @@ function inventory_tab.build(map_data, player_data)
 	for item_hash, count in pairs(inventory_provided) do
 		item, quality = unhash_signal(item_hash)
 		local item_prototype = util.prototype_from_name(item)
-		local signal = util.signalid_from_prototype(item_prototype, quality)
+		local signal = util.signalid_from_name(item, quality)
 		provided_children[#provided_children + 1] = {
 			type = "choose-elem-button",
 			elem_type = "signal",
@@ -201,7 +201,7 @@ function inventory_tab.build(map_data, player_data)
 	for item_hash, count in pairs(inventory_requested) do
 		item, quality = unhash_signal(item_hash)
 		local item_prototype = util.prototype_from_name(item)
-		local signal = util.signalid_from_prototype(item_prototype, quality)
+		local signal = util.signalid_from_name(item, quality)
 		requested_children[#requested_children + 1] = {
 			type = "choose-elem-button",
 			elem_type = "signal",
@@ -232,7 +232,7 @@ function inventory_tab.build(map_data, player_data)
 	for item_hash, count in pairs(inventory_in_transit) do
 		item, quality = unhash_signal(item_hash)
 		local item_prototype = util.prototype_from_name(item)
-		local signal = util.signalid_from_prototype(item_prototype, quality)
+		local signal = util.signalid_from_name(item, quality)
 		in_transit_children[#in_transit_children + 1] = {
 			type = "choose-elem-button",
 			elem_type = "signal",

--- a/cybersyn/scripts/gui/inventory.lua
+++ b/cybersyn/scripts/gui/inventory.lua
@@ -167,11 +167,10 @@ function inventory_tab.build(map_data, player_data)
 	local inventory_provided_table = refs.inventory_provided_table
 	local provided_children = {}
 
-	local i = 0
 	for item_hash, count in pairs(inventory_provided) do
 		item, quality = unhash_signal(item_hash)
-		local signal = util.signalid_from_name(item, quality)
-		i = i + 1
+		local item_prototype = util.prototype_from_name(item)
+		local signal = util.signalid_from_prototype(item_prototype, quality)
 		provided_children[#provided_children + 1] = {
 			type = "choose-elem-button",
 			elem_type = "signal",
@@ -181,6 +180,7 @@ function inventory_tab.build(map_data, player_data)
 			tooltip = {
 				"",
 				util.rich_text_from_signal(signal),
+				" ", item_prototype.localised_name,
 				" provided",
 				"\n Amount: " .. format.number(count),
 			},
@@ -198,11 +198,10 @@ function inventory_tab.build(map_data, player_data)
 	local inventory_requested_table = refs.inventory_requested_table
 	local requested_children = {}
 
-	local i = 0
 	for item_hash, count in pairs(inventory_requested) do
 		item, quality = unhash_signal(item_hash)
-		local signal = util.signalid_from_name(item, quality)
-		i = i + 1
+		local item_prototype = util.prototype_from_name(item)
+		local signal = util.signalid_from_prototype(item_prototype, quality)
 		requested_children[#requested_children + 1] = {
 			type = "choose-elem-button",
 			elem_type = "signal",
@@ -212,6 +211,7 @@ function inventory_tab.build(map_data, player_data)
 			tooltip = {
 				"",
 				util.rich_text_from_signal(signal),
+				" ", item_prototype.localised_name,
 				" requested",
 				"\n Amount: " .. format.number(count),
 			},
@@ -229,11 +229,10 @@ function inventory_tab.build(map_data, player_data)
 	local inventory_in_transit_table = refs.inventory_in_transit_table
 	local in_transit_children = {}
 
-	local i = 0
 	for item_hash, count in pairs(inventory_in_transit) do
 		item, quality = unhash_signal(item_hash)
-		local signal = util.signalid_from_name(item, quality)
-		i = i + 1
+		local item_prototype = util.prototype_from_name(item)
+		local signal = util.signalid_from_prototype(item_prototype, quality)
 		in_transit_children[#in_transit_children + 1] = {
 			type = "choose-elem-button",
 			elem_type = "signal",
@@ -243,6 +242,7 @@ function inventory_tab.build(map_data, player_data)
 			tooltip = {
 				"",
 				util.rich_text_from_signal(signal),
+				" ", item_prototype.localised_name,
 				" in transit",
 				"\n Amount: " .. format.number(count),
 			},

--- a/cybersyn/scripts/gui/util.lua
+++ b/cybersyn/scripts/gui/util.lua
@@ -82,14 +82,24 @@ function util.prototype_from_name(name)
 		   prototypes.quality[name]
 end
 
---- Creates a SignalID structure from a prototype and optional quality.
----@param prototype LuaPrototypeBase
+--- Creates a SignalID structure from an item name and optional quality.
+---@param name string
 ---@param quality string?
 ---@return SignalID
-function util.signalid_from_prototype(prototype, quality)
+function util.signalid_from_name(name, quality)
+	---@type SignalIDType
+	-- TODO is there a better way to get item type from name?
+	local signal_type = prototypes.item[name] ~= nil and "item" or
+			prototypes.fluid[name] ~= nil and "fluid" or
+			prototypes.virtual_signal[name] ~= nil and "virtual" or
+			prototypes.entity[name] ~= nil and "entity" or
+			prototypes.recipe[name] ~= nil and "recipe" or
+			prototypes.space_location[name] ~= nil and "space-location" or
+			prototypes.asteroid_chunk[name] ~= nil and "asteroid-chunk" or
+			"quality"
 	return {
-		type = prototype.type,
-		name = prototype.name,
+		type = signal_type,
+		name = name,
 		quality = quality,
 	}
 end
@@ -104,7 +114,7 @@ function util.slot_table_build_from_manifest(manifest, color)
 	if manifest then
 		for _, item in pairs(manifest) do
 			local item_prototype = util.prototype_from_name(item.name)
-			local signal = util.signalid_from_prototype(item_prototype, item.quality)
+			local signal = util.signalid_from_name(item.name, item.quality)
 			children[#children + 1] = {
 				type = "choose-elem-button",
 				elem_type = "signal",
@@ -206,7 +216,7 @@ function util.slot_table_build_from_deliveries(station)
 	for item_hash, count in pairs(deliveries) do
 		item, quality = unhash_signal(item_hash)
 		local item_prototype = util.prototype_from_name(item)
-		local signal = util.signalid_from_prototype(item_prototype, quality)
+		local signal = util.signalid_from_name(item, quality)
 
 		local color
 		if count > 0 then

--- a/cybersyn/scripts/gui/util.lua
+++ b/cybersyn/scripts/gui/util.lua
@@ -290,8 +290,17 @@ function util.slot_table_build_from_control_signals(station, map_data)
 			local name = item.name
 			local color = "default"
 
+			local stack_tooltip_str = ""
 			if station.is_stack and (not item.type or item.type == "item") then
+				stack_tooltip_str = ", " .. count .. " stacks"
 				count = count * get_stack_size(map_data, name)
+			end
+			local item_prototype = util.prototype_from_name(name)
+
+			-- Indicate request threshold in tooltip if signal is item/fluid
+			local request_threshold_tooltip_str = " "
+			if not item.type or item.type == "item" or item.type == "fluid" then
+				request_threshold_tooltip_str = " Request threshold for "
 			end
 
 			children[#children + 1] = {
@@ -299,8 +308,15 @@ function util.slot_table_build_from_control_signals(station, map_data)
 				elem_type = "signal",
 				signal = item,
 				enabled = false,
-				ignored_by_interaction = true,
 				style = "ltnm_small_slot_button_" .. color,
+				tooltip = {
+					"",
+					util.rich_text_from_signal(item),
+					request_threshold_tooltip_str,
+					item_prototype.localised_name,
+					"\n Amount: " .. format.number(count),
+					stack_tooltip_str,
+				},
 				children = {
 					{
 						type = "label",


### PR DESCRIPTION
Per request of someone from discord - sometimes its not clear from the icon what item it is (modded icons can look similar)

Adds:
* localized item names into GUI tooltips
* tooltips for the "Control signals" column in the "Stations" tab

![Screenshot 2024-12-19 124517](https://github.com/user-attachments/assets/ddba0bb0-b81c-4688-bc73-f5474387694c)

![Screenshot 2024-12-19 124355](https://github.com/user-attachments/assets/c21bfbc0-635a-4bff-ac95-b9c251360698)

* tooltip for station control signals:

Tooltip for item/fluid signals - explains this is the requester threshold for the item + says amount of stacks if `Stack thresholds` is enabled

![Screenshot 2024-12-25 181049](https://github.com/user-attachments/assets/54939bec-b188-4437-9ef3-581bede4027e)
![Screenshot 2024-12-25 181106](https://github.com/user-attachments/assets/f196e8be-afce-46df-817f-76171e673c31)

If its a virtual signal (like requester threshold) a default tooltip is used:

![Screenshot 2024-12-25 183604](https://github.com/user-attachments/assets/fa90d2f1-f14a-4a01-803e-3baeaa1b579c)


