### PR TITLE
feat: GUI - add station count label + tooltip info to inventory tab

### DIFF
--- a/cybersyn/prototypes/gui-style.lua
+++ b/cybersyn/prototypes/gui-style.lua
@@ -310,6 +310,25 @@ styles.ltnm_label_signal_count = {
 	right_padding = 4,
 }
 
+styles.ltnm_label_train_count_inventory = {
+	type = "label_style",
+	parent = "count_label",
+	size = 36,
+	width = 36,
+	horizontal_align = "right",
+	vertical_align = "top",
+	right_padding = 3,
+	top_padding = -4,
+	parent_hovered_font_color = { 1, 1, 1 },
+}
+
+styles.ltnm_label_train_count = {
+	type = "label_style",
+	parent = "ltnm_label_train_count_inventory",
+	right_padding = 6,
+	top_padding = -5,
+}
+
 local hovered_label_color = {
 	r = 0.5 * (1 + default_orange_color.r),
 	g = 0.5 * (1 + default_orange_color.g),

--- a/cybersyn/scripts/gui/inventory.lua
+++ b/cybersyn/scripts/gui/inventory.lua
@@ -167,11 +167,10 @@ function inventory_tab.build(map_data, player_data)
 	local inventory_provided_table = refs.inventory_provided_table
 	local provided_children = {}
 
-	local i = 0
 	for item_hash, count in pairs(inventory_provided) do
 		item, quality = unhash_signal(item_hash)
-		local signal = util.signalid_from_name(item, quality)
-		i = i + 1
+		local item_prototype = util.prototype_from_name(item)
+		local signal = util.signalid_from_prototype(item_prototype, quality)
 		provided_children[#provided_children + 1] = {
 			type = "choose-elem-button",
 			elem_type = "signal",
@@ -181,6 +180,7 @@ function inventory_tab.build(map_data, player_data)
 			tooltip = {
 				"",
 				util.rich_text_from_signal(signal),
+				" ", item_prototype.localised_name,
 				" provided",
 				"\n Amount: " .. format.number(count),
 			},
@@ -198,11 +198,10 @@ function inventory_tab.build(map_data, player_data)
 	local inventory_requested_table = refs.inventory_requested_table
 	local requested_children = {}
 
-	local i = 0
 	for item_hash, count in pairs(inventory_requested) do
 		item, quality = unhash_signal(item_hash)
-		local signal = util.signalid_from_name(item, quality)
-		i = i + 1
+		local item_prototype = util.prototype_from_name(item)
+		local signal = util.signalid_from_prototype(item_prototype, quality)
 		requested_children[#requested_children + 1] = {
 			type = "choose-elem-button",
 			elem_type = "signal",
@@ -212,6 +211,7 @@ function inventory_tab.build(map_data, player_data)
 			tooltip = {
 				"",
 				util.rich_text_from_signal(signal),
+				" ", item_prototype.localised_name,
 				" requested",
 				"\n Amount: " .. format.number(count),
 			},
@@ -229,11 +229,10 @@ function inventory_tab.build(map_data, player_data)
 	local inventory_in_transit_table = refs.inventory_in_transit_table
 	local in_transit_children = {}
 
-	local i = 0
 	for item_hash, count in pairs(inventory_in_transit) do
 		item, quality = unhash_signal(item_hash)
-		local signal = util.signalid_from_name(item, quality)
-		i = i + 1
+		local item_prototype = util.prototype_from_name(item)
+		local signal = util.signalid_from_prototype(item_prototype, quality)
 		in_transit_children[#in_transit_children + 1] = {
 			type = "choose-elem-button",
 			elem_type = "signal",
@@ -243,6 +242,7 @@ function inventory_tab.build(map_data, player_data)
 			tooltip = {
 				"",
 				util.rich_text_from_signal(signal),
+				" ", item_prototype.localised_name,
 				" in transit",
 				"\n Amount: " .. format.number(count),
 			},

--- a/cybersyn/scripts/gui/inventory.lua
+++ b/cybersyn/scripts/gui/inventory.lua
@@ -126,9 +126,10 @@ function inventory_tab.build(map_data, player_data)
 				if item.type ~= "virtual" then
 					if station.is_p and count > 0 then
 						if inventory_provided[item_hash] == nil then
-							inventory_provided[item_hash] = count
+							inventory_provided[item_hash] = {count, 1}
 						else
-							inventory_provided[item_hash] = inventory_provided[item_hash] + count
+							inventory_provided[item_hash][1] = inventory_provided[item_hash][1] + count
+							inventory_provided[item_hash][2] = inventory_provided[item_hash][2] + 1
 						end
 					end
 					if station.is_r and count < 0 then
@@ -136,13 +137,13 @@ function inventory_tab.build(map_data, player_data)
 						if station.is_stack and item.type ~= "fluid" then
 							r_threshold = r_threshold * get_stack_size(map_data, item.name)
 						end
-						-- FIXME handle v.signal.quality
 
 						if -count >= r_threshold then
 							if inventory_requested[item_hash] == nil then
-								inventory_requested[item_hash] = count
+								inventory_requested[item_hash] = {count, 1}
 							else
-								inventory_requested[item_hash] = inventory_requested[item_hash] + count
+								inventory_requested[item_hash][1] = inventory_requested[item_hash][1] + count
+								inventory_requested[item_hash][2] = inventory_requested[item_hash][2] + 1
 							end
 						end
 					end
@@ -155,9 +156,10 @@ function inventory_tab.build(map_data, player_data)
 			for item_hash, count in pairs(deliveries) do
 				if count > 0 then
 					if inventory_in_transit[item_hash] == nil then
-						inventory_in_transit[item_hash] = count
+						inventory_in_transit[item_hash] = {count, 1}
 					else
-						inventory_in_transit[item_hash] = inventory_in_transit[item_hash] + count
+						inventory_in_transit[item_hash][1] = inventory_in_transit[item_hash][1] + count
+						inventory_in_transit[item_hash][2] = inventory_in_transit[item_hash][2] + 1
 					end
 				end
 			end
@@ -167,8 +169,9 @@ function inventory_tab.build(map_data, player_data)
 	local inventory_provided_table = refs.inventory_provided_table
 	local provided_children = {}
 
-	for item_hash, count in pairs(inventory_provided) do
+	for item_hash, counts in pairs(inventory_provided) do
 		item, quality = unhash_signal(item_hash)
+		local item_count, station_count = table.unpack(counts)
 		local item_prototype = util.prototype_from_name(item)
 		local signal = util.signalid_from_prototype(item_prototype, quality)
 		provided_children[#provided_children + 1] = {
@@ -180,16 +183,23 @@ function inventory_tab.build(map_data, player_data)
 			tooltip = {
 				"",
 				util.rich_text_from_signal(signal),
-				" ", item_prototype.localised_name,
-				" provided",
-				"\n Amount: " .. format.number(count),
+				" ", item_prototype.localised_name, "\n",
+				"Provided by ", tostring(station_count), " station",
+				(station_count > 1 and "s" or ""), "\n",
+				"Amount: " .. format.number(item_count),
 			},
 			children = {
 				{
 					type = "label",
 					style = "ltnm_label_signal_count_inventory",
 					ignored_by_interaction = true,
-					caption = format_signal_count(count),
+					caption = format_signal_count(item_count),
+				},
+				{
+					type = "label",
+					style = "ltnm_label_train_count_inventory",
+					ignored_by_interaction = true,
+					caption = format_signal_count(station_count),
 				},
 			},
 		}
@@ -198,8 +208,9 @@ function inventory_tab.build(map_data, player_data)
 	local inventory_requested_table = refs.inventory_requested_table
 	local requested_children = {}
 
-	for item_hash, count in pairs(inventory_requested) do
+	for item_hash, counts in pairs(inventory_requested) do
 		item, quality = unhash_signal(item_hash)
+		local item_count, station_count = table.unpack(counts)
 		local item_prototype = util.prototype_from_name(item)
 		local signal = util.signalid_from_prototype(item_prototype, quality)
 		requested_children[#requested_children + 1] = {
@@ -211,16 +222,23 @@ function inventory_tab.build(map_data, player_data)
 			tooltip = {
 				"",
 				util.rich_text_from_signal(signal),
-				" ", item_prototype.localised_name,
-				" requested",
-				"\n Amount: " .. format.number(count),
+				" ", item_prototype.localised_name, "\n",
+				"Requested by ", tostring(station_count), " station",
+				(station_count > 1 and "s" or ""), "\n",
+				"Amount: " .. format.number(item_count),
 			},
 			children = {
 				{
 					type = "label",
 					style = "ltnm_label_signal_count_inventory",
 					ignored_by_interaction = true,
-					caption = format_signal_count(count),
+					caption = format_signal_count(item_count),
+				},
+				{
+					type = "label",
+					style = "ltnm_label_train_count_inventory",
+					ignored_by_interaction = true,
+					caption = format_signal_count(station_count),
 				},
 			},
 		}
@@ -229,8 +247,9 @@ function inventory_tab.build(map_data, player_data)
 	local inventory_in_transit_table = refs.inventory_in_transit_table
 	local in_transit_children = {}
 
-	for item_hash, count in pairs(inventory_in_transit) do
+	for item_hash, counts in pairs(inventory_in_transit) do
 		item, quality = unhash_signal(item_hash)
+		local item_count, station_count = table.unpack(counts)
 		local item_prototype = util.prototype_from_name(item)
 		local signal = util.signalid_from_prototype(item_prototype, quality)
 		in_transit_children[#in_transit_children + 1] = {
@@ -242,16 +261,23 @@ function inventory_tab.build(map_data, player_data)
 			tooltip = {
 				"",
 				util.rich_text_from_signal(signal),
-				" ", item_prototype.localised_name,
-				" in transit",
-				"\n Amount: " .. format.number(count),
+				" ", item_prototype.localised_name, "\n",
+				"In transit to ", tostring(station_count), " station",
+				(station_count > 1 and "s" or ""), "\n",
+				"Amount: " .. format.number(item_count),
 			},
 			children = {
 				{
 					type = "label",
 					style = "ltnm_label_signal_count_inventory",
 					ignored_by_interaction = true,
-					caption = format_signal_count(count),
+					caption = format_signal_count(item_count),
+				},
+				{
+					type = "label",
+					style = "ltnm_label_train_count_inventory",
+					ignored_by_interaction = true,
+					caption = format_signal_count(station_count),
 				},
 			},
 		}


### PR DESCRIPTION
Adds information into GUI inventory tab about how many stations are requesting/providing/in-transit each item. This info is added as a label + into a tooltip.

![Screenshot 2024-12-23 224935](https://github.com/user-attachments/assets/474ac155-9fa1-46e4-b360-c8417a3b3d16)

If you feel like there are too many numbers already, the label can be omitted if it would be '1'.

**NOTE** this PR is built upon this https://github.com/mamoniot/project-cybersyn/pull/244 PR because there would be conflicts otherwise. Merging this will also apply that PR. If merging only this PR is wanted, let me know I'll arrange it.

