### PR TITLE
fix: invisible GUI filter, rebuild from player_data

### DIFF
--- a/cybersyn/scripts/gui/manager.lua
+++ b/cybersyn/scripts/gui/manager.lua
@@ -155,6 +155,21 @@ function manager.build(player_data)
 			player_data.search_surface_idx = nil
 		end
 	end
+
+	-- sometimes manager_item_filter picked item is not saved for some reason
+	-- and then items are filtered but there is no indication in the GUI
+	-- restore the GUI elem from player_data here as a workaround
+	if player_data.search_item then
+		--- @type LuaGuiElement
+		local item_filter_elem = refs.manager_item_filter
+		item_filter_elem.elem_value = util.signalid_from_name(player_data.search_item)
+	end
+
+	-- same as above but for the network GUI elem
+	if player_data.search_network_name then
+		local network_filter_elem = refs.network
+		network_filter_elem.elem_value = util.signalid_from_name(player_data.search_network_name)
+	end
 end
 
 --- @param map_data MapData


### PR DESCRIPTION
Sometimes after loading a save file, the item filter (and also network filter) in the GUI would indicate no filter selected. However there still is a filter in player_data.
This PR autoselects item and network filters for the GUI element from player_data structure, so GUI and filters are always in sync.

As a side-effect, quality on item and network filters is cleared in the GUI (that's good because the filtering also ignores quality).

I have no idea why sometimes the GUI element does not save its state like this.