### PR TITLE
Add support for quality wagon fluid size

### DIFF
--- a/cybersyn/scripts/global.lua
+++ b/cybersyn/scripts/global.lua
@@ -29,6 +29,11 @@
 ---@class PerfCache
 ---@field public se_get_space_elevator_name {}?
 ---@field public se_get_zone_from_surface_index {}?
+---@field public size_fluidwagon_cache {[string]: FluidWagonSize} -- name of fluid wagon
+
+---@class FluidWagonSize
+---@field public fluid_normal_size uint -- size of wagon in normal quality
+---@field public quality_size {[uint] : uint} -- level of quality : size of wagon with this level of quality
 
 ---@class Cybersyn.StationScheduleSettings
 ---@field public enable_inactive true? If true, enable inactivity timeouts for trains at this station.

--- a/cybersyn/scripts/global.lua
+++ b/cybersyn/scripts/global.lua
@@ -30,6 +30,7 @@
 ---@field public se_get_space_elevator_name {}?
 ---@field public se_get_zone_from_surface_index {}?
 ---@field public size_fluidwagon_cache {[string]: FluidWagonSize} -- name of fluid wagon
+---@field public fluid_name_test string -- name of the fluid to test quality fluid wagon
 
 ---@class FluidWagonSize
 ---@field public fluid_normal_size uint -- size of wagon in normal quality

--- a/cybersyn/scripts/layout.lua
+++ b/cybersyn/scripts/layout.lua
@@ -97,13 +97,17 @@ function set_train_layout(map_data, train)
 			item_slot_capacity = item_slot_capacity + #inv
 		elseif carriage.type == "fluid-wagon" then
 			layout[#layout + 1] = 2
-
-			--This is absolutely the only way of knowing how big a fluid wagon is with quality right now
-			local oldfluid = carriage.get_fluid(1)
-			carriage.clear_fluid_inside()
-			local fluidsize = carriage.insert_fluid({name="water", amount=1e10})
-			fluid_capacity = fluid_capacity + fluidsize
-			carriage.set_fluid(1, oldfluid)
+			if carriage.quality.level == 0 then
+				fluid_capacity = fluid_capacity + carriage.prototype.fluid_capacity
+			else
+				--This is absolutely the only way of knowing how big a fluid wagon is with quality right now
+				local oldfluid = carriage.get_fluid(1)
+				carriage.set_fluid(1, nil)
+				local fluidsize = carriage.insert_fluid({name="water", amount=1e10})
+				carriage.set_fluid(1, oldfluid)
+				
+				fluid_capacity = fluid_capacity + fluidsize
+			end
 		else
 			layout[#layout + 1] = 0
 		end

--- a/cybersyn/scripts/layout.lua
+++ b/cybersyn/scripts/layout.lua
@@ -83,7 +83,6 @@ function remove_train(map_data, train_id, train)
 end
 
 
-local size_fluidwagon_cache = {}
 ---@param map_data MapData
 ---@param train Train
 function set_train_layout(map_data, train)
@@ -92,6 +91,9 @@ function set_train_layout(map_data, train)
 	local i = 1
 	local item_slot_capacity = 0
 	local fluid_capacity = 0
+	if not map_data.perf_cache.size_fluidwagon_cache then
+		map_data.perf_cache.size_fluidwagon_cache = {}
+	end
 	for _, carriage in pairs(carriages) do
 		if carriage.type == "cargo-wagon" then
 			layout[#layout + 1] = 1
@@ -103,25 +105,25 @@ function set_train_layout(map_data, train)
 				fluid_capacity = fluid_capacity + carriage.prototype.fluid_capacity
 			else
 				local fluidsize = 0
-				if not size_fluidwagon_cache[carriage.prototype.name] then
+				if not map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name] then
 					--fluid wagon not cached yet
-					size_fluidwagon_cache[carriage.prototype.name] = {fluid_normal_size = carriage.prototype.fluid_capacity, quality_size = {}}
+					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name] = {fluid_normal_size = carriage.prototype.fluid_capacity, quality_size = {}}
 				end
-				if size_fluidwagon_cache[carriage.prototype.name].fluid_normal_size ~= carriage.prototype.fluid_capacity then
+				if map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].fluid_normal_size ~= carriage.prototype.fluid_capacity then
 					--fluid_capacity has changed so recalculating all quality
-					size_fluidwagon_cache[carriage.prototype.name].fluid_normal_size = carriage.prototype.fluid_capacity
-					size_fluidwagon_cache[carriage.prototype.name].quality_size = {}
+					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].fluid_normal_size = carriage.prototype.fluid_capacity
+					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size = {}
 				end
-				if not size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level] then
+				if not map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level] then
 					--This is absolutely the only way of knowing how big a fluid wagon is with quality right now
 					local oldfluid = carriage.get_fluid(1)
 					carriage.set_fluid(1, nil)
 					--fluid-unknown should always exist in factorio
 					fluidsize = carriage.insert_fluid({name="fluid-unknown", amount=1e10})
 					carriage.set_fluid(1, oldfluid)
-					size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level] = fluidsize
+					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level] = fluidsize
 				else
-					fluidsize = size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level]
+					fluidsize = map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level]
 				end
 				fluid_capacity = fluid_capacity + fluidsize
 			end

--- a/cybersyn/scripts/layout.lua
+++ b/cybersyn/scripts/layout.lua
@@ -82,6 +82,8 @@ function remove_train(map_data, train_id, train)
 	interface_raise_train_removed(train_id, train)
 end
 
+
+local size_fluidwagon_cache = {}
 ---@param map_data MapData
 ---@param train Train
 function set_train_layout(map_data, train)
@@ -100,13 +102,27 @@ function set_train_layout(map_data, train)
 			if carriage.quality.level == 0 or #prototypes.fluid == 0 then
 				fluid_capacity = fluid_capacity + carriage.prototype.fluid_capacity
 			else
-				--This is absolutely the only way of knowing how big a fluid wagon is with quality right now
-				local oldfluid = carriage.get_fluid(1)
-				carriage.set_fluid(1, nil)
-				--fluid-unknown should always exist in factorio
-				local fluidsize = carriage.insert_fluid({name="fluid-unknown", amount=1e10})
-				carriage.set_fluid(1, oldfluid)
-
+				local fluidsize = 0
+				if not size_fluidwagon_cache[carriage.prototype.name] then
+					--fluid wagon not cached yet
+					size_fluidwagon_cache[carriage.prototype.name] = {fluid_normal_size = carriage.prototype.fluid_capacity, quality_size = {}}
+				end
+				if size_fluidwagon_cache[carriage.prototype.name].fluid_normal_size ~= carriage.prototype.fluid_capacity then
+					--fluid_capacity has changed so recalculating all quality
+					size_fluidwagon_cache[carriage.prototype.name].fluid_normal_size = carriage.prototype.fluid_capacity
+					size_fluidwagon_cache[carriage.prototype.name].quality_size = {}
+				end
+				if not size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level] then
+					--This is absolutely the only way of knowing how big a fluid wagon is with quality right now
+					local oldfluid = carriage.get_fluid(1)
+					carriage.set_fluid(1, nil)
+					--fluid-unknown should always exist in factorio
+					fluidsize = carriage.insert_fluid({name="fluid-unknown", amount=1e10})
+					carriage.set_fluid(1, oldfluid)
+					size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level] = fluidsize
+				else
+					fluidsize = size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level]
+				end
 				fluid_capacity = fluid_capacity + fluidsize
 			end
 		else

--- a/cybersyn/scripts/layout.lua
+++ b/cybersyn/scripts/layout.lua
@@ -94,6 +94,20 @@ function set_train_layout(map_data, train)
 	if not map_data.perf_cache.size_fluidwagon_cache then
 		map_data.perf_cache.size_fluidwagon_cache = {}
 	end
+	if not map_data.perf_cache.fluid_name_test then -- Getting the fluid to test quality wagon
+		local fluidnametest = "fluid-unknown" -- should be always in the game
+		if not prototypes.fluid[fluidnametest] then
+			fluidnametest = "water" -- fall back to water
+			if not prototypes.fluid[fluidnametest] then
+				fluidnametest = ""
+				for _,k in pairs(prototypes.fluid) do -- try to get the first fluid
+					fluidnametest = _
+					break
+				end
+			end
+		end
+		map_data.perf_cache.fluid_name_test = fluidnametest
+	end
 	for _, carriage in pairs(carriages) do
 		if carriage.type == "cargo-wagon" then
 			layout[#layout + 1] = 1
@@ -101,24 +115,10 @@ function set_train_layout(map_data, train)
 			item_slot_capacity = item_slot_capacity + #inv
 		elseif carriage.type == "fluid-wagon" then
 			layout[#layout + 1] = 2
-			if carriage.quality.level == 0 then
+			if carriage.quality.level == 0 or map_data.perf_cache.size_fluidwagon_cache.fluid_name_test == "" then
 				fluid_capacity = fluid_capacity + carriage.prototype.fluid_capacity
 			else
-				local fluidnametest = "fluid-unknown"
 				local fluidsize = 0
-				if not prototypes.fluid[fluidnametest] then
-					fluidnametest = "water" -- fall back to water
-					if not prototypes.fluid[fluidnametest] then
-						fluidnametest = nil
-						for _,k in pairs(prototypes.fluid) do -- try to get the first fluid
-							fluidnametest = _
-							break
-						end
-						if not fluidnametest then -- no fluid abort everything
-							goto endfluidsize
-						end
-					end
-				end
 				if not map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name] then
 					--fluid wagon not cached yet
 					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name] = {fluid_normal_size = carriage.prototype.fluid_capacity, quality_size = {}}
@@ -133,7 +133,7 @@ function set_train_layout(map_data, train)
 					local oldfluid = carriage.get_fluid(1)
 					carriage.set_fluid(1, nil)
 					--fluid-unknown should always exist in factorio
-					fluidsize = carriage.insert_fluid({name=fluidnametest, amount=1e10})
+					fluidsize = carriage.insert_fluid({name=map_data.perf_cache.fluid_name_test, amount=1e10})
 					carriage.set_fluid(1, oldfluid)
 					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[carriage.quality.level] = fluidsize
 				else

--- a/cybersyn/scripts/layout.lua
+++ b/cybersyn/scripts/layout.lua
@@ -97,15 +97,16 @@ function set_train_layout(map_data, train)
 			item_slot_capacity = item_slot_capacity + #inv
 		elseif carriage.type == "fluid-wagon" then
 			layout[#layout + 1] = 2
-			if carriage.quality.level == 0 then
+			if carriage.quality.level == 0 or #prototypes.fluid == 0 then
 				fluid_capacity = fluid_capacity + carriage.prototype.fluid_capacity
 			else
 				--This is absolutely the only way of knowing how big a fluid wagon is with quality right now
 				local oldfluid = carriage.get_fluid(1)
 				carriage.set_fluid(1, nil)
-				local fluidsize = carriage.insert_fluid({name="water", amount=1e10})
+				--fluid-unknown should always exist in factorio
+				local fluidsize = carriage.insert_fluid({name="fluid-unknown", amount=1e10})
 				carriage.set_fluid(1, oldfluid)
-				
+
 				fluid_capacity = fluid_capacity + fluidsize
 			end
 		else

--- a/cybersyn/scripts/layout.lua
+++ b/cybersyn/scripts/layout.lua
@@ -139,7 +139,6 @@ function set_train_layout(map_data, train)
 				else
 					fluidsize = map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[carriage.quality.level]
 				end
-				::endfluidsize::
 				fluid_capacity = fluid_capacity + fluidsize
 			end
 		else

--- a/cybersyn/scripts/layout.lua
+++ b/cybersyn/scripts/layout.lua
@@ -101,10 +101,24 @@ function set_train_layout(map_data, train)
 			item_slot_capacity = item_slot_capacity + #inv
 		elseif carriage.type == "fluid-wagon" then
 			layout[#layout + 1] = 2
-			if carriage.quality.level == 0 or #prototypes.fluid == 0 then
+			if carriage.quality.level == 0 then
 				fluid_capacity = fluid_capacity + carriage.prototype.fluid_capacity
 			else
+				local fluidnametest = "fluid-unknown"
 				local fluidsize = 0
+				if not prototypes.fluid[fluidnametest] then
+					fluidnametest = "water" -- fall back to water
+					if not prototypes.fluid[fluidnametest] then
+						fluidnametest = nil
+						for _,k in pairs(prototypes.fluid) do -- try to get the first fluid
+							fluidnametest = _
+							break
+						end
+						if not fluidnametest then -- no fluid abort everything
+							goto endfluidsize
+						end
+					end
+				end
 				if not map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name] then
 					--fluid wagon not cached yet
 					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name] = {fluid_normal_size = carriage.prototype.fluid_capacity, quality_size = {}}
@@ -119,12 +133,13 @@ function set_train_layout(map_data, train)
 					local oldfluid = carriage.get_fluid(1)
 					carriage.set_fluid(1, nil)
 					--fluid-unknown should always exist in factorio
-					fluidsize = carriage.insert_fluid({name="fluid-unknown", amount=1e10})
+					fluidsize = carriage.insert_fluid({name=fluidnametest, amount=1e10})
 					carriage.set_fluid(1, oldfluid)
 					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[carriage.quality.level] = fluidsize
 				else
 					fluidsize = map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[carriage.quality.level]
 				end
+				::endfluidsize::
 				fluid_capacity = fluid_capacity + fluidsize
 			end
 		else

--- a/cybersyn/scripts/layout.lua
+++ b/cybersyn/scripts/layout.lua
@@ -97,7 +97,13 @@ function set_train_layout(map_data, train)
 			item_slot_capacity = item_slot_capacity + #inv
 		elseif carriage.type == "fluid-wagon" then
 			layout[#layout + 1] = 2
-			fluid_capacity = fluid_capacity + carriage.prototype.fluid_capacity
+
+			--This is absolutely the only way of knowing how big a fluid wagon is with quality right now
+			local oldfluid = carriage.get_fluid(1)
+			carriage.clear_fluid_inside()
+			local fluidsize = carriage.insert_fluid({name="water", amount=1e10})
+			fluid_capacity = fluid_capacity + fluidsize
+			carriage.set_fluid(1, oldfluid)
 		else
 			layout[#layout + 1] = 0
 		end

--- a/cybersyn/scripts/layout.lua
+++ b/cybersyn/scripts/layout.lua
@@ -114,16 +114,16 @@ function set_train_layout(map_data, train)
 					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].fluid_normal_size = carriage.prototype.fluid_capacity
 					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size = {}
 				end
-				if not map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level] then
+				if not map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[carriage.quality.level] then
 					--This is absolutely the only way of knowing how big a fluid wagon is with quality right now
 					local oldfluid = carriage.get_fluid(1)
 					carriage.set_fluid(1, nil)
 					--fluid-unknown should always exist in factorio
 					fluidsize = carriage.insert_fluid({name="fluid-unknown", amount=1e10})
 					carriage.set_fluid(1, oldfluid)
-					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level] = fluidsize
+					map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[carriage.quality.level] = fluidsize
 				else
-					fluidsize = map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[""..carriage.quality.level]
+					fluidsize = map_data.perf_cache.size_fluidwagon_cache[carriage.prototype.name].quality_size[carriage.quality.level]
 				end
 				fluid_capacity = fluid_capacity + fluidsize
 			end


### PR DESCRIPTION
My name on discord is vextexfux I've opened a bug report and I tried to fix it this is what I found to get the actual size of a fluid wagon when quality change the size of it.
The only way of knowing the actual size of a fluid wagon is to insert an absurdly ammount of a fluid : water in this case and checking how much it got inserted.
I'm also opening a thread on factorio forum to request a new function to get fluid size with quality.
