### PR TITLE
Add a recalculation of all trains when requested by a command and when a mod is changed

### DIFF
--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -76,6 +76,7 @@ no-train-matches-p-layout=Could not find a train on the allow-list of __2__ to m
 station-non-default-priority=Train misdirected by Factorio priority at this station. Using non-default Factorio priority with Project Cybersyn WILL cause incorrect deliveries. You can fix problematic stations with /cybersyn-fix-priorities.
 fix-priorities-command-help=Resets the priority of problematic train stops back to 50
 find-problems-command-help=Locates train stops that cause problems in the Cybersyn network
+recalculate-train-size-command-help=Recalculate all trains wagon size
 
 [cybersyn-problems]
 no-problems-found=The [img=item/construction-robot] bots ran their checklist on all your Cybersyn stations and have nothing to report [img=virtual-signal/signal-check].

--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -76,7 +76,7 @@ no-train-matches-p-layout=Could not find a train on the allow-list of __2__ to m
 station-non-default-priority=Train misdirected by Factorio priority at this station. Using non-default Factorio priority with Project Cybersyn WILL cause incorrect deliveries. You can fix problematic stations with /cybersyn-fix-priorities.
 fix-priorities-command-help=Resets the priority of problematic train stops back to 50
 find-problems-command-help=Locates train stops that cause problems in the Cybersyn network
-recalculate-train-size-command-help=Recalculate all trains wagon size
+recalculate-train-size-command-help=Recalculate all trains wagon capacities
 
 [cybersyn-problems]
 no-problems-found=The [img=item/construction-robot] bots ran their checklist on all your Cybersyn stations and have nothing to report [img=virtual-signal/signal-check].

--- a/cybersyn/scripts/commands.lua
+++ b/cybersyn/scripts/commands.lua
@@ -179,21 +179,23 @@ local function fix_priorities_command()
 	end
 end
 
-function retrigger_train_calculation()
+function retrigger_train_calculation(print_message)
 	---@type MapData
 	local map_data = storage
-	log("Recalculating all train sizes")
+	log("Recalculating all train capacities")
 	local nbtrains = 0
 	for _,train in pairs(map_data.trains) do
 		set_train_layout(map_data, train)
 		nbtrains = nbtrains+1
 	end
-	game.print("All ".. nbtrains .. " train size recalculated.")
+	if print_message then
+		game.print("All ".. nbtrains .. " train capacities recalculated.")
+	end
 	log("Recalculated "..nbtrains.." trains")
 end
 
 commands.add_command("cybersyn-recalculate-train-size", { "cybersyn-messages.recalculate-train-size-command-help" },
-retrigger_train_calculation)
+	function() retrigger_train_calculation(true) end)
 commands.add_command("cybersyn-find-problems", { "cybersyn-messages.find-problems-command-help" },
 	function() find_problems(report_print) end)
 commands.add_command("cybersyn-fix-priorities", { "cybersyn-messages.fix-priorities-command-help" },

--- a/cybersyn/scripts/commands.lua
+++ b/cybersyn/scripts/commands.lua
@@ -179,6 +179,21 @@ local function fix_priorities_command()
 	end
 end
 
+function retrigger_train_calculation()
+	---@type MapData
+	local map_data = storage
+	log("Recalculating all train sizes")
+	local nbtrains = 0
+	for _,train in pairs(map_data.trains) do
+		set_train_layout(map_data, train)
+		nbtrains = nbtrains+1
+	end
+	game.print("All ".. nbtrains .. " train size recalculated.")
+	log("Recalculated "..nbtrains.." trains")
+end
+
+commands.add_command("cybersyn-recalculate-train-size", { "cybersyn-messages.recalculate-train-size-command-help" },
+retrigger_train_calculation)
 commands.add_command("cybersyn-find-problems", { "cybersyn-messages.find-problems-command-help" },
 	function() find_problems(report_print) end)
 commands.add_command("cybersyn-fix-priorities", { "cybersyn-messages.fix-priorities-command-help" },

--- a/cybersyn/scripts/migrations.lua
+++ b/cybersyn/scripts/migrations.lua
@@ -352,6 +352,7 @@ function on_config_changed(data)
 			on_debug_revision_change()
 		end
 	end
+	retrigger_train_calculation()
 end
 
 ---NOTE: this runs before on_config_changed

--- a/cybersyn/scripts/migrations.lua
+++ b/cybersyn/scripts/migrations.lua
@@ -352,7 +352,8 @@ function on_config_changed(data)
 			on_debug_revision_change()
 		end
 	end
-	retrigger_train_calculation()
+	
+	retrigger_train_calculation(false)
 end
 
 ---NOTE: this runs before on_config_changed


### PR DESCRIPTION
it's pretty basic but it works well.
I've added a command cybersyn-recalculate-train-size to recalculate all trains and I've added the function on on_configuration_changed too.