### PR TITLE
Fix: Handle schedules running empty

### DIFF
--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -77,6 +77,8 @@ station-non-default-priority=Train misdirected by Factorio priority at this stat
 fix-priorities-command-help=Resets the priority of problematic train stops back to 50
 find-problems-command-help=Locates train stops that cause problems in the Cybersyn network
 control-train-group=Train group __1__ is now used by Cybersyn for depot(s) __2__. Do [color=yellow]not[/color] modify the group's base schedule.
+train-group-schedule-broken=Train group __1__ has an empty base schedule. Trains have nowhere to go after a delivery.
+train-schedule-broken=A train has nowhere to go after a delivery.
 
 [cybersyn-problems]
 no-problems-found=The [img=item/construction-robot] bots ran their checklist on all your Cybersyn stations and have nothing to report [img=virtual-signal/signal-check].


### PR DESCRIPTION
I have also added a check that removes trains from Cybersyn if they are found to have an empty schedule.
It's better to keep trains where they were found to have no schedule than to send them somewhere else even if they could potentially be used for other deliveries (but eventually have nowhere to go).

The alert this generates distinguishes between single trains and train groups to help the player find the reason the schedule became empty.
