### PR TITLE
FIx layout checks for inserters

### DIFF
--- a/cybersyn/scripts/layout.lua
+++ b/cybersyn/scripts/layout.lua
@@ -596,18 +596,18 @@ function reset_stop_layout(map_data, stop, is_station_or_refueler, forbidden_ent
 							local pos = entity.pickup_position
 							local is_there
 							if is_ver then
-								is_there = middle_x - 1 <= pos.x and pos.x <= middle_x + 1
+								is_there = middle_x - 1 <= pos.x and pos.x <= middle_x + 1 and search_area[1][2] <= pos.y and pos.y <= search_area[2][2]
 							else
-								is_there = middle_y - 1 <= pos.y and pos.y <= middle_y + 1
+								is_there = middle_y - 1 <= pos.y and pos.y <= middle_y + 1 and search_area[1][1] <= pos.x and pos.x <= search_area[2][1]
 							end
 							if is_there then
 								supports_cargo = true
 							else
 								pos = entity.drop_position
 								if is_ver then
-									is_there = middle_x - 1 <= pos.x and pos.x <= middle_x + 1
+									is_there = middle_x - 1 <= pos.x and pos.x <= middle_x + 1 and search_area[1][2] <= pos.y and pos.y <= search_area[2][2]
 								else
-									is_there = middle_y - 1 <= pos.y and pos.y <= middle_y + 1
+									is_there = middle_y - 1 <= pos.y and pos.y <= middle_y + 1 and search_area[1][1] <= pos.x and pos.x <= search_area[2][1]
 								end
 								if is_there then
 									supports_cargo = true


### PR DESCRIPTION
Hi! I found an edge case in the layout analyzer where some inserters are incorrectly attributed to a specific wagon, even though they can't actually insert into it.

This can happen when an inserter has a larger collision box than the standard 1x1 size. Since `surface.find_entities_filtered` returns any entity that at least partially overlaps with the area near the wagon, and the current implementation only checks one coordinate for the pickup/drop position, an inserter can be incorrectly considered able to insert into a wagon.

This is demonstrated in the screenshot below. I'm using [pY Cranes](https://mods.factorio.com/mod/pycranes) and placed an inserter exactly between two wagons, so it can't insert into either one. However, the allow-list shows a wagon for both the first and second positions. (Note: it may not be clear from the screenshot, but the inserter entity is actually placed, not a ghost.)
![Screenshot 2025-05-18 143629](https://github.com/user-attachments/assets/6177780d-1686-41a9-8343-215225b037c9)


In the fix, I simply reused the search_area to check whether the pickup or drop-off position is within the expected bounds along both coordinates.