### PR TITLE
Remove migrated names from economy and deliveries

### DIFF
--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -58,6 +58,23 @@ local function get_network_name_from_item_network_name(item_network_name)
 	return network_name
 end
 
+---@param item_network_name Cybersyn.Economy.ItemNetworkName
+---@return string network_name
+---@return string item_name
+---@return string? item_quality
+function parse_item_network_name(item_network_name)
+	local s, e = string.find(item_network_name, ":", 1, true)
+	if not (s and e) then
+		error(item_network_name.." is no ItemNetworkName")
+	end
+
+	local network_name = string.sub(item_network_name, 1, s - 1)
+	local item_hash = string.sub(item_network_name, e + 1)
+	local item_name, item_quality = unhash_signal(item_hash)
+
+	return network_name, item_name, item_quality
+end
+
 ---Trains are not allowed to move further than one surface away from their home surface.
 ---This only checks if the train would be allowed to travel, not if travel is actually possible.
 ---@param train_surface uint surface index of the train

--- a/cybersyn/scripts/commands.lua
+++ b/cybersyn/scripts/commands.lua
@@ -5,7 +5,7 @@ local function gps_text(entity)
 end
 
 ---@param train LuaTrain
-local function train_richtext(train)
+function train_richtext(train)
 	local _, loco = next(train.locomotives.front_movers)
 	if loco then
 		return "[train="..loco.unit_number.."]"

--- a/cybersyn/scripts/migrations.lua
+++ b/cybersyn/scripts/migrations.lua
@@ -386,6 +386,83 @@ local migrations_table = {
 		end
 	end
 }
+
+function sanitize_economy_names()
+	---@type MapData
+	local map_data = storage
+
+	local proto = {
+		item = prototypes.item,
+		fluid = prototypes.fluid,
+	}
+
+	local removed = {}
+
+	local all_names = map_data.economy.all_names
+	for i, entry in ipairs(map_data.economy.all_names) do
+		if type(entry) == "string" then
+			local _, item_name, _ = parse_item_network_name(entry)
+			if not (proto.item[item_name] or proto.fluid[item_name]) then
+				all_names[i] = nil
+				removed[item_name] = true
+			end
+		else
+			if not proto[entry.type][entry.name] then
+				all_names[i] = nil
+				removed[entry.name] = true
+			end
+		end
+	end
+
+	local all_p_stations = map_data.economy.all_p_stations
+	for item_network_name, _ in pairs(all_p_stations) do
+		local _, item_name, _ = parse_item_network_name(item_network_name)
+		if not (proto.item[item_name] or proto.fluid[item_name]) then
+			all_p_stations[item_network_name] = nil
+			removed[item_name] = true
+		end
+	end
+
+	local all_r_stations = map_data.economy.all_r_stations
+	for item_network_name, _ in pairs(all_r_stations) do
+		local _, item_name, _ = parse_item_network_name(item_network_name)
+		if not (proto.item[item_name] or proto.fluid[item_name]) then
+			all_r_stations[item_network_name] = nil
+			removed[item_name] = true
+		end
+	end
+
+	for _, station in pairs(map_data.stations) do
+		local deliveries = station.deliveries
+		if deliveries then
+			for item_hash, _ in pairs(deliveries) do
+				local item_name, _ = unhash_signal(item_hash)
+				if not (proto.item[item_name] or proto.fluid[item_name]) then
+					deliveries[item_hash] = nil
+					removed[item_name] = true
+				end
+			end
+		end
+	end
+
+	if next(removed) then
+		log("Migrated names removed from economy: "..serpent.block(removed, {sortkeys = true}))
+	end
+
+	for train_id, train in pairs(map_data.trains) do
+		if train.manifest then
+			for _, entry in pairs(train.manifest) do
+				if not proto[entry.type][entry.name] then
+					local msg = string.format("%s delivery aborted: %s no longer exists", train_richtext(train.entity), entry.name)
+					log(msg)
+					game.print(msg)
+					remove_train(map_data, train_id, train)
+				end
+			end
+		end
+	end
+end
+
 --STATUS_R_TO_D = 5
 ---@param data ConfigurationChangedData
 function on_config_changed(data)
@@ -402,6 +479,10 @@ function on_config_changed(data)
 		if debug_revision then
 			on_debug_revision_change()
 		end
+	end
+
+	if data.migration_applied then
+		sanitize_economy_names()
 	end
 
 	retrigger_train_calculation(false)


### PR DESCRIPTION
There is no API to get the new names so renaming is impossible.