### PR TITLE
Lock train only for missing stations and refuelers

### DIFF
--- a/cybersyn/scripts/train-events.lua
+++ b/cybersyn/scripts/train-events.lua
@@ -546,7 +546,7 @@ function on_train_changed(event)
 							elseif station.entity_comb.valid then
 								on_train_arrives_refueler(map_data, station, train_id, train)
 							end
-						else
+						elseif is_station ~= nil then -- STATUS_TO_(P|R|F) but station is gone
 							remove_train(map_data, train_id, train)
 							lock_train(train_e)
 							if is_station then


### PR DESCRIPTION
#294 did not consider `train.state`s other than `STATUS_TO_(P|R|F)`. 

For those it is normal to not have a station and nothing should happen.