### PR TITLE
Fix crash when elevator travel happens out of order

### DIFF
--- a/cybersyn/scripts/mod-compatibility/se-elevator-travel.lua
+++ b/cybersyn/scripts/mod-compatibility/se-elevator-travel.lua
@@ -72,6 +72,12 @@ local function se_add_direct_to_station_order(map_data, train, schedule, found_c
 		return schedule_offset -- no change to schedule
 	end
 
+	-- Factorio does not allow adding temporary rail stops on different surfaces.
+	local rolling_stock = get_any_train_entity(train.entity)
+	if not rolling_stock or rolling_stock.surface_index ~= station.entity_stop.surface_index then
+		return schedule_offset
+	end
+
 	local real_index = found_cybersyn_stop.schedule_index + schedule_offset
 	local is_current_destination = schedule.current == real_index
 	local direct_to_station = create_direct_to_station_order(station.entity_stop)


### PR DESCRIPTION
```
Error while running event cybersyn::Custom event (ID 292)
LuaEntity belongs to surface nauvis (index 1) but a LuaEntity belonging to surface Nauvis Orbit (index 3) was expected.
stack traceback:
	[C]: in function 'add_record'
	...ersyn__/scripts/mod-compatibility/se-elevator-travel.lua:79: in function 'se_add_direct_to_station_order'
	...ersyn__/scripts/mod-compatibility/se-elevator-travel.lua:104: in function 'se_add_direct_to_station_orders'
	...ersyn__/scripts/mod-compatibility/se-elevator-travel.lua:169: in function <...ersyn__/scripts/mod-compatibility/se-elevator-travel.lua:123>
stack traceback:
	[C]: in function 'raise_event'
	__space-exploration__/scripts/space-elevator.lua:590: in function 'finish_teleport'
	__space-exploration__/scripts/space-elevator.lua:873: in function 'space_elevator_teleport_next'
	__space-exploration__/scripts/space-elevator.lua:1527: in function 'space_elevator_tick'
	__space-exploration__/scripts/space-elevator.lua:1537: in function 'callback'
	__space-exploration__/scripts/event.lua:20: in function <__space-exploration__/scripts/event.lua:18>
```

Can happen when a Cybersyn train is manually told to skip parts of its delivery schedule and travel through an elevator.