### PR TITLE
Avoid no path to first schedule entry

### DIFF
--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -212,7 +212,7 @@ function create_delivery(map_data, r_station_id, p_station_id, train_id, manifes
 	local is_at_depot = remove_available_train(map_data, train_id, train)
 	--NOTE: we assume that the train is not being teleported at this time
 	--NOTE: set_manifest_schedule is allowed to cancel the delivery at the last second if applying the schedule to the train makes it lost and is_at_depot == false
-	if set_manifest_schedule(map_data, train.entity, depot.entity_stop, not train.use_any_depot, p_station.entity_stop, p_station, r_station.entity_stop, r_station, manifest, surface_connections, is_at_depot) then
+	if set_manifest_schedule(map_data, train, depot.entity_stop, not train.use_any_depot, p_station.entity_stop, p_station, r_station.entity_stop, r_station, manifest, surface_connections, is_at_depot) then
 		local old_status = train.status
 		train.status = STATUS_TO_P
 		train.p_station_id = p_station_id
@@ -749,10 +749,12 @@ local function tick_dispatch(map_data, mod_settings)
 		end
 
 		if best_train_id then
-			local p_station_id = table_remove(p_stations, p_station_i)
-			move_stations_to_end_of_polling_queue(map_data, p_station_id, r_station_id)
+			local p_station_id = p_stations[p_station_i]
 			local manifest = create_manifest(map_data, r_station_id, p_station_id, best_train_id, item_name)
-			create_delivery(map_data, r_station_id, p_station_id, best_train_id, manifest, best_surface_connections)
+			if create_delivery(map_data, r_station_id, p_station_id, best_train_id, manifest, best_surface_connections) then
+				table_remove(p_stations, p_station_i)
+				move_stations_to_end_of_polling_queue(map_data, p_station_id, r_station_id)
+			end
 			return false
 		else
 			if closest_to_correct_p_station then
@@ -987,6 +989,7 @@ function tick_poll_entities(map_data, mod_settings)
 	local tick_data = map_data.tick_data
 
 	if map_data.total_ticks % 5 == 0 then
+		local tick = game.tick
 		if tick_data.last_train == nil or map_data.trains[tick_data.last_train] then
 			local train_id, train = next(map_data.trains, tick_data.last_train)
 			tick_data.last_train = train_id
@@ -1003,6 +1006,8 @@ function tick_poll_entities(map_data, mod_settings)
 						send_alert_stuck_train(map_data, train.entity)
 					end
 					interface_raise_train_stuck(train_id)
+				elseif train.status == STATUS_TO_D_BYPASS and tick >= (train.skip_path_checks_until or 0) then
+					add_available_train(map_data, train_id, train)
 				end
 			end
 		else

--- a/cybersyn/scripts/constants.lua
+++ b/cybersyn/scripts/constants.lua
@@ -41,6 +41,7 @@ NETWORK_ANYTHING = "signal-anything"
 NETWORK_EACH = "signal-each"
 INACTIVITY_TIME = 100
 LOCK_TRAIN_TIME = 60 * 60 * 60 * 24 * 7
+NO_PATH_SKIP_TIME = 5 * 60 -- 5s
 
 DELTA = 1 / 2048
 

--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -373,6 +373,88 @@ function clean_temporary_records(schedule)
 	end
 end
 
+---@class ScheduleBuilder : Class
+---@field public records AddRecordData[]
+---@field public stops (LuaEntity?)[]
+---@field private i integer
+---@field private same_surface boolean
+---@field private include_ids boolean
+ScheduleBuilder = Class:derive()
+
+---@protected
+function ScheduleBuilder:new()
+	local instance = self:derive(Class:new())
+	instance.records = {}
+	instance.stops = {}
+	instance.i = 0
+	instance.same_surface = true
+	instance.include_ids = false
+	return instance
+end
+
+function ScheduleBuilder:use_ids()
+	self.include_ids = true
+end
+
+---Adds the given record.
+---@param record AddRecordData? nil values are skipped
+---@param stop LuaEntity? the stop that's associated with the record, if any
+function ScheduleBuilder:add(record, stop)
+	if record then
+		local i = self.i + 1
+		self.records[i] = record
+		self.stops[i] = stop
+		self.i = i
+	end
+end
+
+---Adds the given record and prevents further direct_to_stop records.
+---@param record AddRecordData? nil values are skipped and dont prevent further direct_to_station records
+---@param stop LuaEntity? the stop that's associated with the record, if any
+function ScheduleBuilder:add_surface_travel(record, stop)
+	if record then
+		local i = self.i + 1
+		self.records[i] = record
+		self.stops[i] = stop
+		self.i = i
+		self.same_surface = false
+		self.include_ids = true
+	end
+end
+
+---Adds a temporary rail record for the given train stop if there was no previous surface travel.
+---@param stop LuaEntity? invalid stops are skipped
+function ScheduleBuilder:add_direct_to_stop(stop)
+	if self.same_surface and stop and stop.valid then
+		local i = self.i + 1
+		self.records[i] = create_direct_to_station_order(stop)
+		self.stops[i] = stop
+		self.i = i
+	end
+end
+
+---@param p_stop LuaEntity
+---@param manifest Manifest
+---@param p_schedule_settings Cybersyn.StationScheduleSettings
+function ScheduleBuilder:add_loading_order(p_stop, manifest, p_schedule_settings)
+	self:add_direct_to_stop(p_stop)
+	self:add(create_loading_order(p_stop, manifest, p_schedule_settings, self.include_ids), p_stop)
+end
+
+---@param r_stop LuaEntity
+---@param manifest Manifest
+---@param r_schedule_settings Cybersyn.StationScheduleSettings
+function ScheduleBuilder:add_unloading_order(r_stop, manifest, r_schedule_settings)
+	self:add_direct_to_stop(r_stop)
+	self:add(create_unloading_order(r_stop, manifest, self.include_ids), r_stop)
+end
+
+---@param f_stop LuaEntity
+function ScheduleBuilder:add_refuel_order(f_stop)
+	self:add_direct_to_stop(f_stop)
+	self:add(create_inactivity_order(f_stop.backer_name, self.include_ids and REFUELER_ID_ITEM or nil, f_stop.unit_number), f_stop)
+end
+
 ---Inserts the given records before the first non-interrupt record in the schedule
 ---@param schedule LuaSchedule
 ---@param records AddRecordData[] supports optional entries by skipping falsy ones
@@ -458,19 +540,18 @@ function set_manifest_schedule(
 		t_surface == r_surface and
 		t_surface == d_surface
 
-	local records = nil
+	local new_schedule = nil
 
 	if all_same_surface then
-		records = {
-			create_direct_to_station_order(p_stop),
-			create_loading_order(p_stop, manifest, p_schedule_settings),
-			create_direct_to_station_order(r_stop),
-			create_unloading_order(r_stop, r_schedule_settings),
-			same_depot and create_direct_to_station_order(depot_stop) or nil,
-		}
+		new_schedule = ScheduleBuilder:new()
+		new_schedule:add_loading_order(p_stop, manifest, p_schedule_settings)
+		new_schedule:add_unloading_order(r_stop, manifest, r_schedule_settings)
+		if same_depot then
+			new_schedule:add_direct_to_stop(depot_stop)
+		end
 	else
 		if IS_SE_PRESENT then
-			records = ElevatorTravel.se_set_manifest_schedule(
+			new_schedule = ElevatorTravel.se_set_manifest_schedule(
 				train,
 				depot_stop,
 				same_depot,
@@ -487,8 +568,8 @@ function set_manifest_schedule(
 		-- if not records and OTHER_TRAVEL_METHOD then ...
 	end
 
-	if records and next(records) then
-		local insert_index = add_records_after_interrupt(schedule, records)
+	if new_schedule and next(new_schedule.records) then
+		local insert_index = add_records_after_interrupt(schedule, new_schedule.records)
 		if start_at_depot then
 			schedule.go_to_station(schedule.get_record_count() --[[@as int]])
 		elseif schedule.current > insert_index then
@@ -527,29 +608,27 @@ function add_refueler_schedule(map_data, data)
 	end
 
 	local schedule = data.t_schedule
-	local records = nil
+	local new_schedule = nil
 
 	if data.all_same_surface then
-		records = {
-			create_direct_to_station_order(stop),
-			create_inactivity_order(stop.backer_name),
-			-- no need to deal with direct-to-depot, must already be present and won't be removed
-		}
+		new_schedule = ScheduleBuilder:new()
+		new_schedule:add_refuel_order(stop)
+		-- no need to deal with direct-to-depot, must already be present and won't be removed
 	else
 		if IS_SE_PRESENT then
-			records = ElevatorTravel.se_add_refueler_schedule(map_data, data)
+			new_schedule = ElevatorTravel.se_add_refueler_schedule(map_data, data)
 		end
 
 		-- if not records and OTHER_TRAVEL_METHOD then ...
 	end
 
-	if records and next(records) then
+	if new_schedule and next(new_schedule.records) then
 		if not data.all_same_surface then
 			-- inter-surface travel has to provide a completely new Cybersyn schedule
 			clean_temporary_records(schedule)
 		end
 
-		local refueler_index = add_records_after_interrupt(schedule, records)
+		local refueler_index = add_records_after_interrupt(schedule, new_schedule.records)
 		if schedule.current >= refueler_index then
 			schedule.go_to_station(refueler_index)
 		end

--- a/cybersyn/scripts/global.lua
+++ b/cybersyn/scripts/global.lua
@@ -119,6 +119,7 @@
 ---@field public se_is_being_teleported true? --se only
 ---@field public se_awaiting_removal any? --se only
 ---@field public se_awaiting_rename any? --se only
+---@field public skip_path_checks_until int?
 
 ---@alias Manifest ManifestEntry[]
 ---@class ManifestEntry


### PR DESCRIPTION
Currently trains that are traveling and are available for new deliveries can be in a rail segment where there's no path to the first stop in the delivery schedule. Notably this happens for bi-directional trains in intersections, especially those of dead-end-stations. With Space Exploration normal trains that are heading towards a space elevator can also be affected.

The building blocks to get rid of the problem are
1. Use ScheduleBuilder for all deliveries (and refueling orders for consistency) and keep track of added stops in addition to schedule records (which only contain station names).
2. Do an extra [path-query](https://lua-api.factorio.com/stable/classes/LuaTrainManager.html#request_train_path) to check that the train can reach the first stop in the schedule *before* applying the schedule.
  This only needs to happen for delivery assignments that happen mid-travel, so only for `STATUS_TO_D_BYPASS`.
  Refueling orders don't need to check this because they only get issued in state `STATUS_R`, so not when traveling.
3. If the check fails, abort creating the delivery and make the train unavailable for 5s.
  This avoids excessive path queries and gives the train the opportunity to drive somewhere it can find a path again.
  Economy data will be unchanged, so the planner will try to create the delivery again, choosing a different train this time, if one is available.