### PR TITLE
Fix crash when updating a station's layout

### DIFF
--- a/cybersyn/scripts/gui.lua
+++ b/cybersyn/scripts/gui.lua
@@ -310,13 +310,16 @@ end
 
 ---@param e EventData.on_gui_click
 local function handle_refresh_allow(e)
-	-- < function interface.reset_stop_layout(stop_id, forbidden_entity, force_update)
 	local combId = e.element.tags.id
 	local stop = storage.to_stop[combId]
-	if stop == nil then return end
-	local stopId = stop.unit_number
-	remote.call("cybersyn", "reset_stop_layout", stopId, nil, true)
-	update_allow_list_section(e.player_index, combId)
+	if not stop or not stop.valid then return end
+
+	local station = storage.stations[stop.unit_number]
+	local stationOrRefueler = station or storage.refuelers[stop.unit_number]
+	if stationOrRefueler then
+		reset_stop_layout(storage, stationOrRefueler, station ~= nil)
+	end
+	update_allow_list_section(e.player_index, combId) -- will update to X, if stationOrRefueler is nil
 end
 
 ---@alias EntityOpenedHandler fun(event: EventData.on_gui_opened, player: LuaPlayer, entity: LuaEntity, is_ghost: boolean) player and entity are guaranteed to be valid, is_ghost indicates if the entity is a ghost


### PR DESCRIPTION
This addresses the crash reported in #247, it does not address the underlying problem that a station looses its state.