### PR TITLE
Warn about elevators with the same name

### DIFF
--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -99,6 +99,8 @@ train-group-schedule-broken=Train group __1__ has an empty base schedule. Trains
 train-schedule-broken=A train has nowhere to go after a delivery.
 elevator-connected=Connected elevator __1__ to Cybersyn
 elevator-disconnected=Disconnected elevator __1__ from Cybersyn
+other-elevator-enabled=[img=virtual-signal/se-warning] Trains will still use it because elevator __1__ is still connected. [color=cyan]Assign distinct names to the elevators to avoid this situation.[/color]
+other-elevator-disabled=[img=virtual-signal/se-warning] Trains will also use elevator __1__ even though it is disconnected. [color=cyan]Assign distinct names to the elevators to avoid this situation.[/color]
 
 [cybersyn-problems]
 no-problems-found=The [img=item/construction-robot] bots ran their checklist on all your Cybersyn stations and have nothing to report [img=virtual-signal/signal-check].


### PR DESCRIPTION
Elevators don't get coordinate stops in the schedule, so players need to know that connecting elevators to Cybersyn affects other elevators with the same name and that this can be avoided by renaming the elevators.