### PR TITLE
Remove case sensitivity in station search

### DIFF
--- a/cybersyn/scripts/gui/stations.lua
+++ b/cybersyn/scripts/gui/stations.lua
@@ -76,6 +76,11 @@ function stations_tab.build(map_data, player_data, query_limit)
 	local stations_sorted = {}
 	local to_sorted_manifest = {}
 
+	if (search_query) then
+		-- lowercase search query to remove case sensitivity 
+		search_query = search_query:lower()
+	end
+
 	local i = 0
 	for id, station in pairs(stations) do
 		local entity = station.entity_stop
@@ -84,7 +89,7 @@ function stations_tab.build(map_data, player_data, query_limit)
 		end
 
 		if search_query then
-			if not string.match(entity.backer_name, search_query) then
+			if not string.match(entity.backer_name:lower(), search_query) then
 				goto continue
 			end
 		end


### PR DESCRIPTION
When searching for stations in the GUI is unexpectedly case sensitive while all other search boxes throughout the game are insensitive to my knowledge. This small change removes the sensitivity by lowercasing strings before comparing. 