### PR TITLE
Remove alert for train pathfinding failure

### DIFF
--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -617,7 +617,6 @@ function set_manifest_schedule(
 	end
 
 	train_stuck()
-	send_alert_cannot_path_between_surfaces(map_data, train_e)
 	return true
 end
 


### PR DESCRIPTION
Removed alert sending when train cannot find path between surfaces.

Hi, per our discussion, I am submitting this PR to remove the redundant alert when cross-surface pathing fails without SE.

**Reasoning:**
As confirmed, surface connectivity is checked earlier in the logic chain. If the code reaches this point (e.g., when a compatibility mod like "Portals" is handling the schedule via script intervention), raising an alert is unnecessary and causes audio spam for the player.

**Changes:**
- Removed the `send_alert_cannot_path_between_surfaces(map_data, train_e)` call in `set_manifest_schedule`.
- Kept `train_stuck()` to ensure the train stops safely in manual mode if no external script handles it.

I have tested this locally, and it successfully silences the alert while allowing the train to be correctly managed by external schedulers without side effects.