### PR TITLE
Fix: Occasional "No Path" error for cross-surface return trips 

### DIFF
--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -540,7 +540,7 @@ function set_manifest_schedule(
 
 	local train_e = train.entity
 	local schedule = train_e.get_schedule()
-	clean_temporary_records(schedule)
+
 
 	-- creates a schedule that cannot be fulfilled, the train will be stuck but it will give the player information what went wrong
 	function train_stuck()
@@ -606,6 +606,7 @@ function set_manifest_schedule(
 			train.skip_path_checks_until = game.tick + NO_PATH_SKIP_TIME
 			return false
 		end
+		clean_temporary_records(schedule)
 
 		local insert_index = add_records_after_interrupt(schedule, new_schedule.records)
 		if start_at_depot then


### PR DESCRIPTION
Hello! This PR addresses an issue where trains (especially using Space Exploration elevators) occasionally lose their return path and get stuck with a "No Path" error after completing a delivery.

**The Problem:**

The issue occurs when a train in `STATUS_TO_D_BYPASS` state is considered for a new delivery by the dispatcher (`tick_dispatch`).

1.  The `set_manifest_schedule()` function is called to assign the new task.
2.  Crucially, it calls `clean_temporary_records()` at the very beginning, **before** checking if the new path is actually valid (`is_path_available`).
3.  This prematurely removes the train's existing return path (e.g., the temporary space elevator stop).
4.  If the new path calculation then fails (e.g., due to timing, distance, or other constraints), the function returns `false`, but the original return path is **not restored**.
5.  The train is left with a broken schedule (often just the final Depot stop) and gets stuck.


**The Fix:**

This change implements a "Delayed Cleaning" strategy by simply moving the `clean_temporary_records(schedule)` call.

- It is now placed **after** the `if train.status == STATUS_TO_D_BYPASS and not new_schedule:is_path_available(train_e) then` check.

With this change, the old temporary records are only cleared after the new path has been successfully validated. If the new path is invalid, the function returns early, and the train's original schedule remains intact, allowing it to safely return to its depot.

This is a minimal, non-invasive change that fixes the race condition without adding any performance overhead.

I have been testing locally for a long time and have not encountered any further issues.

Just as a follow-up, I also investigated other functions that modify schedules to ensure this race condition doesn't exist elsewhere.

Specifically, I checked `add_refueler_schedule()`. I can confirm that its logic is already safe and correctly structured. It calculates the new path first and only calls `clean_temporary_records()` *after* confirming that a new valid schedule (`new_schedule`) has been generated.

Therefore, the fix in `set_manifest_schedule()` is the only change needed to resolve this specific class of "No Path" errors.

Thank you for your consideration!