### PR TITLE
Generalize Intersurface Travel API for SE & other modsfeat: Add universal intersurface API

### DIFF
--- a/cybersyn/migrations/2025-12-31_v2.0.XX_remove-se-elevators-db.lua
+++ b/cybersyn/migrations/2025-12-31_v2.0.XX_remove-se-elevators-db.lua
@@ -1,0 +1,34 @@
+-- migrations/2025-12-30_remove-se-elevators-db.lua
+
+-- 1. Remove the deprecated se_elevators database.
+if storage.se_elevators then
+	storage.se_elevators = nil
+end
+
+-- 2. [Cleanup] Remove invalid/fake entries from connected_surfaces.
+-- New Cybersyn architecture requires real Userdata (LuaEntity).
+-- Any legacy Lua Table injections (from older compatibility hacks) are considered invalid and must be purged.
+-- Note: Valid connections (like native SE ones) are already Userdata and will be preserved.
+
+if storage.connected_surfaces then
+	local surfaces_to_remove = {}
+
+	for surface_key, connections in pairs(storage.connected_surfaces) do
+		for entity_key, conn in pairs(connections) do
+			-- Strict Check: If it's not a real C++ Entity (userdata), delete it.
+			if type(conn.entity1) ~= "userdata" or type(conn.entity2) ~= "userdata" then
+				connections[entity_key] = nil
+			end
+		end
+
+		-- Mark empty surface keys for removal
+		if next(connections) == nil then
+			surfaces_to_remove[surface_key] = true
+		end
+	end
+
+	-- Final cleanup of empty surface tables
+	for k, _ in pairs(surfaces_to_remove) do
+		storage.connected_surfaces[k] = nil
+	end
+end

--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -581,8 +581,10 @@ function set_manifest_schedule(
 			new_schedule:add_direct_to_stop(depot_stop)
 		end
 	else
-		if IS_SE_PRESENT then
-			new_schedule = ElevatorTravel.se_set_manifest_schedule(
+		-- [Refactored] Check if IntersurfaceTravel module is loaded instead of checking IS_SE_PRESENT.
+		-- This allows generic intersurface travel if surface_connections are provided.
+		if IntersurfaceTravel then
+			new_schedule = IntersurfaceTravel.set_intersurface_manifest_schedule(
 				train_e,
 				depot_stop,
 				same_depot,
@@ -653,8 +655,9 @@ function add_refueler_schedule(map_data, data)
 		new_schedule:add_refuel_order(stop)
 		-- no need to deal with direct-to-depot, must already be present and won't be removed
 	else
-		if IS_SE_PRESENT then
-			new_schedule = ElevatorTravel.se_add_refueler_schedule(map_data, data)
+		-- [Refactored] Generic check for IntersurfaceTravel module.
+		if IntersurfaceTravel then
+			new_schedule = IntersurfaceTravel.add_intersurface_refueler_schedule(map_data, data)
 		end
 
 		-- if not records and OTHER_TRAVEL_METHOD then ...

--- a/cybersyn/scripts/main.lua
+++ b/cybersyn/scripts/main.lua
@@ -917,7 +917,9 @@ local function main()
 
 	script.on_init(function()
 		init_global()
-		ElevatorTravel.setup_se_compat()
+		-- Always set up intersurface/elevator logic.
+		-- It will check for SE presence internally for event registration.
+		IntersurfaceTravel.setup_se_compat()
 		picker_dollies_compat.setup_picker_dollies_compat()
 		manager.on_init()
 	end)
@@ -928,7 +930,8 @@ local function main()
 	end)
 
 	script.on_load(function()
-		ElevatorTravel.setup_se_compat()
+		-- Always set up intersurface/elevator logic.
+		IntersurfaceTravel.setup_se_compat()
 		picker_dollies_compat.setup_picker_dollies_compat()
 	end)
 


### PR DESCRIPTION
#### The Problem

Currently, Cybersyn's intersurface logistics are hard-coded to Space Exploration (SE). This forces other mods with intersurface travel capabilities to use unstable and unsafe hacks to achieve compatibility, such as injecting fake Lua Table entities to mimic SE's internal data structures (`se_elevators`). This approach is fragile and can lead to game crashes if Cybersyn's internal logic changes, creating a poor experience for both players and mod developers.

#### The Solution

This pull request refactors the existing intersurface logic to be universal while maintaining perfect backward compatibility with Space Exploration.

The core idea is to **decouple the general logic from the SE-specific implementation**. This is achieved by introducing a small, clean, and universal Remote Interface that allows any mod to register its transit points with Cybersyn.

**I have been testing these changes locally for many days, and they have proven to be stable and effective.**

#### Detailed Changes

1.  **New Universal Remote Interface**:
    *   Four new functions are added to the remote interface to provide a standard way for mods to interact with Cybersyn's intersurface system. These functions handle connection management and teleportation lifecycle events.
    *   **For other mod developers**:
        *   `remote.call("cybersyn", "register_surface_connection", entity1, entity2, network_masks)`: Registers a connection. `entity1` and `entity2` must be `train-stop` entities. The optional `network_masks` table defaults to `nil` (allowing all networks).
        *   `remote.call("cybersyn", "remove_surface_connection", entity1, entity2)`: Removes a connection.
        *   `remote.call("cybersyn", "on_train_teleport_started", train_id)`: Notifies Cybersyn that a train is about to be teleported.
        *   `remote.call("cybersyn", "on_train_teleported", old_train_id, new_train_entity)`: Notifies Cybersyn that a train has finished teleporting.

2.  **Refactored Pathfinding**:
    *   Pathfinding logic now reads directly from the core `storage.connected_surfaces` table and no longer depends on the `se_elevators` database.
    *   A crash guard (`type(entity) == "userdata"`) has been added to safely ignore invalid or fake data from older mods, preventing game crashes.
    *   The algorithm for finding the closest transit point has been optimized to use squared distance, avoiding `sqrt()` calculations.

3.  **Removed Redundant Database**:
    *   The `storage.se_elevators` database has been completely removed. Its role as a cache for the SE GUI has been replaced by dynamic, on-the-fly checks.

4.  **Backward Compatibility & Smooth Migration**:
    *   The existing `script.on_event` listener for SE's native teleportation events is fully preserved. **SE users will experience no change in functionality.**
    *   A migration script is included to clean up the old `se_elevators` database.
  
5.  **Implementation Notes**:
    *   **Internal Variable Naming**: The internal train flag `train.se_is_being_teleported` **has not been renamed**. While a generic name (e.g., `is_being_teleported`) would be semantically better, changing it would require modifying multiple core files (`central-planning.lua`, `train-events.lua`, etc.), significantly increasing the PR size and conflict risk. The new API wraps this flag, so the internal name remains an implementation detail to keep the diff minimal.
    *   **Symmetry Assumption**: The new API assumes connections are bidirectional (symmetric), inheriting Cybersyn's existing logic. For asymmetric (one-way) travel mods, this can still be handled by registering the connection and using station naming conventions to guide pathfinding, avoiding the need for a complete rewrite of Cybersyn's graph logic.

#### Regarding Maintenance

This refactoring was designed with **minimal maintenance burden** as a core principle:

1.  **No Change to Existing SE Logic Flow**: The core logic for handling SE events remains the same. Debugging any future SE-related issues will be identical to how it is done today.
2.  **Code Simplification**: We have actually *reduced* the complexity of the codebase by removing the redundant `se_elevators` database and all associated hard-coded logic. The new system is simpler and relies on a single source of truth.
3.  **Clear Separation of Concerns**: The new universal API is a thin layer that simply calls the same internal functions that the SE event listeners do. This isolates the universal entry point from the SE-specific one, making the code easier to understand and maintain.

In essence, this PR doesn't add a complex new feature to maintain; it refactors an existing feature to be more robust, more universal, and ultimately, *easier* to maintain in the long run.

