### PR TITLE
Generalize Intersurface Travel API for SE & other modsfeat: Add universal intersurface API 

### DIFF
--- a/cybersyn/migrations/2025-12-31_v2.0.XX_remove-se-elevators-db.lua
+++ b/cybersyn/migrations/2025-12-31_v2.0.XX_remove-se-elevators-db.lua
@@ -1,0 +1,63 @@
+-- migrations/2025-12-30_remove-se-elevators-db.lua
+
+-- 1. Remove the deprecated se_elevators database.
+if storage.se_elevators then
+	storage.se_elevators = nil
+end
+
+-- 2. [Migration] Convert connected_surfaces from old format to new surface-indexed format.
+-- Old format: {entity1 = LuaEntity, entity2 = LuaEntity, network_masks = {...}}
+-- New format: {[surface_index_1] = LuaEntity, [surface_index_2] = LuaEntity, network_masks = {...}}
+
+if storage.connected_surfaces then
+	local surfaces_to_remove = {}
+
+	for surface_key, connections in pairs(storage.connected_surfaces) do
+		for entity_key, conn in pairs(connections) do
+			-- Check if this is old format (has entity1/entity2 fields)
+			if conn.entity1 and conn.entity2 then
+				local entity1 = conn.entity1
+				local entity2 = conn.entity2
+				
+				-- Verify both entities are valid userdata
+				if type(entity1) == "userdata" and entity1.valid and 
+				   type(entity2) == "userdata" and entity2.valid then
+					
+					-- Convert to new surface-indexed format
+					local s1 = entity1.surface.index
+					local s2 = entity2.surface.index
+					connections[entity_key] = {
+						[s1] = entity1,
+						[s2] = entity2,
+						network_masks = conn.network_masks
+					}
+				else
+					-- Invalid entities, remove connection
+					connections[entity_key] = nil
+				end
+			else
+				-- Already in new format or invalid format, check validity
+				local has_valid_entity = false
+				for k, v in pairs(conn) do
+					if type(v) == "userdata" and v.valid then
+						has_valid_entity = true
+						break
+					end
+				end
+				if not has_valid_entity then
+					connections[entity_key] = nil
+				end
+			end
+		end
+
+		-- Mark empty surface keys for removal
+		if next(connections) == nil then
+			surfaces_to_remove[surface_key] = true
+		end
+	end
+
+	-- Final cleanup of empty surface tables
+	for k, _ in pairs(surfaces_to_remove) do
+		storage.connected_surfaces[k] = nil
+	end
+end

--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -581,8 +581,10 @@ function set_manifest_schedule(
 			new_schedule:add_direct_to_stop(depot_stop)
 		end
 	else
-		if IS_SE_PRESENT then
-			new_schedule = ElevatorTravel.se_set_manifest_schedule(
+		-- [Refactored] Check if IntersurfaceTravel module is loaded instead of checking IS_SE_PRESENT.
+		-- This allows generic intersurface travel if surface_connections are provided.
+		if IntersurfaceTravel then
+			new_schedule = IntersurfaceTravel.set_intersurface_manifest_schedule(
 				train_e,
 				depot_stop,
 				same_depot,
@@ -653,8 +655,9 @@ function add_refueler_schedule(map_data, data)
 		new_schedule:add_refuel_order(stop)
 		-- no need to deal with direct-to-depot, must already be present and won't be removed
 	else
-		if IS_SE_PRESENT then
-			new_schedule = ElevatorTravel.se_add_refueler_schedule(map_data, data)
+		-- [Refactored] Generic check for IntersurfaceTravel module.
+		if IntersurfaceTravel then
+			new_schedule = IntersurfaceTravel.add_intersurface_refueler_schedule(map_data, data)
 		end
 
 		-- if not records and OTHER_TRAVEL_METHOD then ...

--- a/cybersyn/scripts/main.lua
+++ b/cybersyn/scripts/main.lua
@@ -917,7 +917,9 @@ local function main()
 
 	script.on_init(function()
 		init_global()
-		ElevatorTravel.setup_se_compat()
+		-- Always set up intersurface/elevator logic.
+		-- It will check for SE presence internally for event registration.
+		IntersurfaceTravel.setup_se_compat()
 		picker_dollies_compat.setup_picker_dollies_compat()
 		manager.on_init()
 	end)
@@ -928,7 +930,8 @@ local function main()
 	end)
 
 	script.on_load(function()
-		ElevatorTravel.setup_se_compat()
+		-- Always set up intersurface/elevator logic.
+		IntersurfaceTravel.setup_se_compat()
 		picker_dollies_compat.setup_picker_dollies_compat()
 	end)
 

--- a/cybersyn/scripts/mod-compatibility/se-elevator-connection.lua
+++ b/cybersyn/scripts/mod-compatibility/se-elevator-connection.lua
@@ -74,15 +74,8 @@ local DESTROY_TYPE_ENTITY = defines.target_type.entity
 
 --- Register with Factorio to clean the Cybersyn surface connection when a corresponding elevator is removed
 function Elevators.on_object_destroyed(e)
-	if not (e.useful_id and e.type == DESTROY_TYPE_ENTITY) then return end
-
-	local data = storage.se_elevators[e.useful_id] -- useful_id for entities is the unit_number
-	if data then
-		storage.se_elevators[data.ground.elevator_id] = nil
-		storage.se_elevators[data.orbit.elevator_id] = nil
-		storage.se_elevators[data.ground.stop_id] = nil
-		storage.se_elevators[data.orbit.stop_id] = nil
-	end
+	-- Intentionally empty: no entities are registered with script.register_on_object_destroyed.
+	-- If you reintroduce registrations or need immediate cleanup on destruction, add it here.
 end
 
 --- Either the surface.index and zone.type of the opposite surface or nil
@@ -102,13 +95,6 @@ local function find_opposite_surface(surface_index)
 	return nil
 end
 
---- Looks up the elevator data for the given unit_number. The data structure *won't* be created if it doesn't exist.
---- @param unit_number integer the unit_number of a `se-space-elevator` or `se-space-elevator-train-stop`
---- @return Cybersyn.ElevatorData|nil
-function Elevators.from_unit_number(unit_number)
-	local elevator = storage.se_elevators[unit_number]
-	return elevator or nil
-end
 
 --- Looks up the elevator data for the given entity. Creates the data structure if it doesn't exist, yet.
 --- @param entity LuaEntity? must be a `se-space-elevator` or `se-space-elevator-train-stop`
@@ -117,63 +103,85 @@ function Elevators.from_entity(entity)
 	if not (entity and entity.valid) then
 		return nil
 	end
-	local data = Elevators.from_unit_number(entity.unit_number)
-	if data then return data end
 
-	-- construct new data
-	if entity.name ~= Elevators.name_elevator and entity.name ~= Elevators.name_stop then
-		error("entity must be an elevator or the corresponding connector entity")
-	end
-
+	-- Identify opposite surface logic remains the same
 	local opposite_surface_index, opposite_zone_type = find_opposite_surface(entity.surface.index)
 	if not opposite_surface_index then return nil end
 
+	-- Find local end
 	local end1 = search_entities(entity.surface, entity.position)
 	if not end1 then return nil end
 
+	-- Find remote end
 	local end2 = search_entities(game.surfaces[opposite_surface_index], entity.position)
 	if not end2 then return nil end
 
-	data = {
+	-- Check if they are currently connected in Cybersyn
+	local surfaces_connected = false
+	local surface_pair_key = sorted_pair(entity.surface.index, opposite_surface_index)
+	local connections = storage.connected_surfaces[surface_pair_key]
+	if connections then
+		-- Verify if this specific pair of stops is connected
+		local entity_pair_key = sorted_pair(end1.stop.unit_number, end2.stop.unit_number)
+		if connections[entity_pair_key] then
+			surfaces_connected = true
+		end
+	end
+
+	-- Construct temporary data object for GUI use
+	local data = {
 		ground = (opposite_zone_type == "planet" or opposite_zone_type == "moon") and end2 or end1,
 		orbit = opposite_zone_type == "orbit" and end2 or end1,
-		-- no entity in the world has this information so reset to "no network restrictions but disabled"
-		cs_enabled = false,
+		cs_enabled = surfaces_connected, -- Dynamic state check
 		network_masks = nil,
 		[entity.surface_index] = end1,
 		[opposite_surface_index] = end2,
 	}
+	
 	if data.ground == data.orbit then
-		error("only know how to handle elevators in zone.type 'planet', 'moon' and 'orbit'")
+		-- This check is kept from original code logic
+		return nil 
 	end
+	
 	data.ground.is_orbit = false
 	data.orbit.is_orbit = true
 
-	storage.se_elevators[data.ground.elevator_id] = data
-	storage.se_elevators[data.orbit.elevator_id] = data
-	storage.se_elevators[data.ground.stop_id] = data
-	storage.se_elevators[data.orbit.stop_id] = data
-
-	-- no need to track by registration number, both entities are valid and must have a unit_number
-	script.register_on_object_destroyed(data.ground.elevator)
-	script.register_on_object_destroyed(data.orbit.elevator)
+	-- We DO NOT register to storage.se_elevators or script.on_object_destroyed here anymore.
+	-- Cleanup is handled by the global on_object_destroyed scan.
 
 	return data
 end
 
 --- @param elevator Cybersyn.ElevatorData
 local function warn_same_elevator_name(elevator)
-	local surface_id = elevator.ground.surface_id
-	for _, other_elevator in pairs(storage.se_elevators) do
-		local ground = other_elevator ~= elevator and other_elevator[surface_id]
-		if ground and other_elevator.cs_enabled ~= elevator.cs_enabled and ground.stop.valid and ground.stop.backer_name == elevator.ground.stop.backer_name then
-			local msgId = "cybersyn-messages.other-elevator-" .. (other_elevator.cs_enabled and "enabled" or "disabled")
-			ground.stop.force.print({ msgId, gps_text(ground.elevator) })
+	-- Check for name collisions against active connections in storage.connected_surfaces.
+	-- storage.connected_surfaces is a nested table: [surface_pair_key] -> { [entity_pair_key] -> connection }
+	
+	local current_name = elevator.ground.stop.backer_name
+	local self_id_1 = elevator.ground.stop.unit_number
+	local self_id_2 = elevator.orbit.stop.unit_number
+
+	-- Iterate through all surface pairs
+	for _, surface_connections in pairs(storage.connected_surfaces) do
+		-- Iterate through specific connections within the surface pair
+		for _, conn in pairs(surface_connections) do
+			-- Iterate through all entities in the connection
+			for _, entity in pairs(conn or {}) do
+				-- Check if entity matches all criteria: valid userdata, not current elevator, and same name
+				if type(entity) == "userdata" and entity.valid and 
+				   entity.unit_number ~= self_id_1 and entity.unit_number ~= self_id_2 and
+				   entity.backer_name == current_name then
+					local msgId = "cybersyn-messages.other-elevator-enabled"
+					elevator.ground.elevator.force.print({ msgId, gps_text(entity) })
+					return
+				end
+			end
 		end
 	end
 end
 
---- Connects or disconnects the eleator from Cybersyn based on cs_enabled and updates the network_id when connected to
+--- Connects or disconnects the elevator from Cybersyn based on cs_enabled
+--- Direct API calls, no database side effects.
 --- @param data Cybersyn.ElevatorData
 function Elevators.update_connection(data)
 	if data.cs_enabled then
@@ -193,10 +201,14 @@ end
 local function se_elevator_toggle(e)
 	local player = assert(game.get_player(e.player_index))
 
+	-- Re-scan entities to get fresh state objects
 	local data = Elevators.from_entity(player.opened --[[@as LuaEntity? ]])
 	if not data then return end
 
+	-- Set the desired state based on switch position
 	data.cs_enabled = e.element.switch_state == "right"
+	
+	-- Apply the change
 	Elevators.update_connection(data)
 end
 
@@ -268,10 +280,11 @@ end
 
 ---@param command CustomCommandData
 local function command_reset_elevators(command)
-	for _, data in pairs(storage.se_elevators) do
-		Surfaces.disconnect_surfaces(data.ground.stop, data.orbit.stop)
-	end
-	storage.se_elevators = {}
+	-- Wipe the entire connection table.
+	storage.connected_surfaces = {}
+	-- Note: storage.se_elevators is deprecated/removed.
+	if storage.se_elevators then storage.se_elevators = nil end
+	
 	game.print("All elevator connections reset.")
 end
 

--- a/cybersyn/scripts/mod-compatibility/se-elevator-travel.lua
+++ b/cybersyn/scripts/mod-compatibility/se-elevator-travel.lua
@@ -1,33 +1,19 @@
 -- Code related to Space Exploration compatibility.
 
-local SE_ELEVATOR_ORBIT_SUFFIX = " ↓"
-local SE_ELEVATOR_PLANET_SUFFIX = " ↑"
-local SE_ELEVATOR_SUFFIX_LENGTH = #SE_ELEVATOR_ORBIT_SUFFIX
-local SE_ELEVATOR_PREFIX = "[img=entity/se-space-elevator]  "
-local SE_ELEVATOR_PREFIX_LENGTH = #SE_ELEVATOR_PREFIX
-
-local string_sub = string.sub
-
 ---Can be used as a predicate with find_next_cybersyn_stop
 ---@param record ScheduleRecord|AddRecordData
 ---@return string? elevator_stop_name
 ---@return boolean? is_ground_to_orbit
-local function se_is_elevator_schedule_record(record)
-	local name = record.station
-	if not name then return end
-
-	local prefix = string_sub(name, 1, SE_ELEVATOR_PREFIX_LENGTH)
-	if prefix == SE_ELEVATOR_PREFIX then
-		local suffix = string_sub(name, -SE_ELEVATOR_SUFFIX_LENGTH)
-		if suffix == SE_ELEVATOR_ORBIT_SUFFIX then
-			return name, false
-		elseif suffix == SE_ELEVATOR_PLANET_SUFFIX then
-			return name, true
-		end
+local function is_transit_schedule_record(record)
+	-- Cybersyn generates transit stops as temporary stops with no wait conditions.
+	-- This allows it to work with any intersurface connection, not just SE elevators.
+	if record.temporary and (not record.wait_conditions or #record.wait_conditions == 0) then
+		return record.station, nil
 	end
+	return nil
 end
 
-ElevatorTravel = {}
+IntersurfaceTravel = {}
 
 ---@param map_data MapData
 ---@param train Train
@@ -99,7 +85,7 @@ local function se_add_direct_to_station_orders(map_data, train)
 	---@type ScheduleSearchOptions
 	local options = {
 		search_index = schedule.current,
-		abort_condition = se_is_elevator_schedule_record, -- stop at the next elevator transition
+		abort_condition = is_transit_schedule_record, -- stop at the next elevator transition
 		include_depot = true,
 	}
 
@@ -113,7 +99,7 @@ local function se_add_direct_to_station_orders(map_data, train)
 	end
 end
 
-local function se_on_train_teleport_started(event)
+function IntersurfaceTravel.on_train_teleport_started(event)
 	---@type MapData
 	local map_data = storage
 	local old_id = event.old_train_id_1
@@ -126,7 +112,7 @@ local function se_on_train_teleport_started(event)
 	interface_raise_train_teleport_started(old_id)
 end
 
-local function se_on_train_teleport_finished(event)
+function IntersurfaceTravel.on_train_teleport_finished(event)
 	---@type MapData
 	local map_data = storage
 	---@type LuaTrain
@@ -176,12 +162,18 @@ local function se_on_train_teleport_finished(event)
 	interface_raise_train_teleported(new_id, old_id)
 end
 
-function ElevatorTravel.setup_se_compat()
+function IntersurfaceTravel.setup_se_compat()
 	IS_SE_PRESENT = remote.interfaces["space-exploration"] ~= nil
-	if not IS_SE_PRESENT then return end
-
-	script.on_event(remote.call("space-exploration", "get_on_train_teleport_finished_event"), se_on_train_teleport_finished)
-	script.on_event(remote.call("space-exploration", "get_on_train_teleport_started_event"), se_on_train_teleport_started)
+	
+	-- Register SE specific events only if SE is present
+	if IS_SE_PRESENT then
+		script.on_event(remote.call("space-exploration", "get_on_train_teleport_finished_event"), IntersurfaceTravel.on_train_teleport_finished)
+		script.on_event(remote.call("space-exploration", "get_on_train_teleport_started_event"), IntersurfaceTravel.on_train_teleport_started)
+	end
+	
+	-- Note: Even if SE is not present, this module is now loaded and 
+	-- IntersurfaceTravel.on_train_teleport_* functions are available for 
+	-- direct calling via remote interface.
 end
 
 ---@param target { [string] : integer }? the network masks of the target
@@ -199,50 +191,49 @@ end
 
 ---@param surface_connections Cybersyn.SurfaceConnection[]
 ---@param network_masks { [string] : integer }?
----@return Cybersyn.ElevatorData[]?
+---@return Cybersyn.SurfaceConnection[]?
 local function se_get_elevators(surface_connections, network_masks)
 	local elevators, i = {}, 0
 	for _, connection in pairs(surface_connections) do
-		if connection.entity1.name == Elevators.name_stop then
-			local elevator = Elevators.from_unit_number(connection.entity1.unit_number)
-			if elevator and has_network_match(elevator.network_masks, network_masks) then
-				i = i + 1
-				elevators[i] = elevator
-			end
+		if has_network_match(connection, network_masks) then
+			i = i + 1
+			elevators[i] = connection
 		end
 	end
 	return i > 0 and elevators or nil
 end
 
----@param elevator_name string
----@param is_train_in_orbit boolean
----@return AddRecordData
-function ElevatorTravel.se_create_elevator_order(elevator_name, is_train_in_orbit)
-	return {
-		station = elevator_name .. (is_train_in_orbit and SE_ELEVATOR_ORBIT_SUFFIX or SE_ELEVATOR_PLANET_SUFFIX),
-		temporary = true,
-	}
-end
-
 ---Creates a schedule record for the elevator that is closest to the given entity
----@param elevators Cybersyn.ElevatorData[] must be elevators on the surface of the given entity
+---@param connections Cybersyn.SurfaceConnection[]
 ---@param from LuaEntity
 ---@return AddRecordData?
 ---@return LuaEntity?
-local function se_create_closest_elevator_travel(elevators, from)
-	local closest, elevator_stop = 2100000000, nil
+local function se_create_closest_elevator_travel(connections, from)
+	local closest_dist_sq = math.huge
+	local elevator_stop = nil
 	local f_surface = from.surface_index
+	local from_pos = from.position
 
-	for _, elevator in ipairs(elevators) do
-		local stop = elevator[f_surface].stop
-		local dist = get_dist(from, stop)
-		if dist < closest then
-			elevator_stop = stop
-			closest = dist
+	for _, conn in ipairs(connections) do
+		-- Directly index by surface for O(1) lookup
+		local stop = conn[f_surface]
+		if stop and stop.valid then
+			-- Calculate squared distance to avoid sqrt()
+			local dx = from_pos.x - stop.position.x
+			local dy = from_pos.y - stop.position.y
+			local dist_sq = dx * dx + dy * dy
+			
+			if dist_sq < closest_dist_sq then
+				elevator_stop = stop
+				closest_dist_sq = dist_sq
+			end
 		end
 	end
 
 	assert(elevator_stop, "travel_data had no elevators")
+	if not elevator_stop or not elevator_stop.valid then 
+		return nil, nil 
+	end
 	return {
 		station = elevator_stop.backer_name,
 		temporary = true,
@@ -250,11 +241,11 @@ local function se_create_closest_elevator_travel(elevators, from)
 end
 
 ---@class SeScheduleBuilder : ScheduleBuilder
----@field private elevators Cybersyn.ElevatorData[]
+---@field private elevators Cybersyn.SurfaceConnection[]
 local SeScheduleBuilder = ScheduleBuilder:derive()
 
 ---@protected
----@param elevators Cybersyn.ElevatorData[]
+---@param elevators Cybersyn.SurfaceConnection[]
 function SeScheduleBuilder:new(elevators)
 	local instance = self:derive(ScheduleBuilder:new())
 	instance.elevators = elevators
@@ -283,7 +274,7 @@ end
 ---@param surface_connections Cybersyn.SurfaceConnection[]
 ---@param start_at_depot boolean?
 ---@return ScheduleBuilder?
-function ElevatorTravel.se_set_manifest_schedule(
+function IntersurfaceTravel.set_intersurface_manifest_schedule(
 		train,
 		depot_stop,
 		same_depot,
@@ -324,7 +315,7 @@ end
 ---@param map_data MapData
 ---@param data RefuelSchedulingData
 ---@return ScheduleBuilder?
-function ElevatorTravel.se_add_refueler_schedule(map_data, data)
+function IntersurfaceTravel.add_intersurface_refueler_schedule(map_data, data)
 	local elevators = se_get_elevators(data.surface_connections)
 	if not elevators then return end -- surface_connections contained no elevators
 

--- a/cybersyn/scripts/surface-connections.lua
+++ b/cybersyn/scripts/surface-connections.lua
@@ -32,7 +32,11 @@ function Surfaces.find_surface_connections_masked(surface1, surface2, network_na
     local count = 0
 
     for entity_pair_key, connection in pairs(surface_connections) do
-        if connection.entity1.valid and connection.entity2.valid then
+        -- Check if both surface-indexed entities are valid
+        local entity1 = connection[surface1]
+        local entity2 = connection[surface2]
+        
+        if entity1 and entity1.valid and entity2 and entity2.valid then
             if not connection.network_masks or btest(network_mask, connection.network_masks[network_name] or 0) then
                 count = count + 1
                 matching_connections[count] = connection
@@ -66,7 +70,11 @@ function Surfaces.find_surface_connections(surface1, surface2)
     local count = 0
 
     for entity_pair_key, connection in pairs(surface_connections) do
-        if connection.entity1.valid and connection.entity2.valid then
+        -- Check if both surface-indexed entities are valid
+        local entity1 = connection[surface1]
+        local entity2 = connection[surface2]
+        
+        if entity1 and entity1.valid and entity2 and entity2.valid then
             count = count + 1
             matching_connections[count] = connection
         else
@@ -150,12 +158,14 @@ function Surfaces.connect_surfaces(entity1, entity2, network_masks)
         entity2.unit_number, entity2.surface.name, entity2.surface.index))
     end
 
-    -- enforce a consistent order for repeated calls with the same two entities
-    if entity2.unit_number < entity1.unit_number then
-        surface_connections[entity_pair_key] = { entity1 = entity2, entity2 = entity1, network_masks = network_masks }
-    else
-        surface_connections[entity_pair_key] = { entity1 = entity1, entity2 = entity2, network_masks = network_masks }
-    end
+    -- Store entities indexed by surface for O(1) lookup during pathfinding
+    local s1 = entity1.surface.index
+    local s2 = entity2.surface.index
+    surface_connections[entity_pair_key] = {
+        [s1] = entity1,
+        [s2] = entity2,
+        network_masks = network_masks
+    }
 
     return is_update and Surfaces.status.updated or Surfaces.status.created
 end


### PR DESCRIPTION
Copilot showed up agaim
Closing this PR to reopen a clean one. The automated Copilot code review bot spammed this thread with irrelevant comments.

#### The Problem

Currently, Cybersyn's intersurface logistics are hard-coded to Space Exploration (SE). This forces other mods with intersurface travel capabilities to use unstable and unsafe hacks to achieve compatibility, such as injecting fake Lua Table entities to mimic SE's internal data structures (`se_elevators`). This approach is fragile and can lead to game crashes if Cybersyn's internal logic changes, creating a poor experience for both players and mod developers.

#### The Solution

This pull request refactors the existing intersurface logic to be universal while maintaining perfect backward compatibility with Space Exploration.

The core idea is to **decouple the general logic from the SE-specific implementation**. This is achieved by introducing a small, clean, and universal Remote Interface that allows any mod to register its transit points with Cybersyn.

**I have been testing these changes locally for many days, and they have proven to be stable and effective.**

#### Detailed Changes

1.  **New Universal Remote Interface**:
    *   Four new functions are added to the remote interface to provide a standard way for mods to interact with Cybersyn's intersurface system. These functions handle connection management and teleportation lifecycle events.
    *   **For other mod developers**:
        *   `remote.call("cybersyn", "register_surface_connection", entity1, entity2, network_masks)`: Registers a connection. `entity1` and `entity2` must be `train-stop` entities. The optional `network_masks` table defaults to `nil` (allowing all networks).
        *   `remote.call("cybersyn", "remove_surface_connection", entity1, entity2)`: Removes a connection.
        *   `remote.call("cybersyn", "on_train_teleport_started", train_id)`: Notifies Cybersyn that a train is about to be teleported.
        *   `remote.call("cybersyn", "on_train_teleported", old_train_id, new_train_entity)`: Notifies Cybersyn that a train has finished teleporting.

2.  **Refactored Pathfinding**:
    *   Pathfinding logic now reads directly from the core `storage.connected_surfaces` table and no longer depends on the `se_elevators` database.
    *   The algorithm for finding the closest transit point has been optimized to use squared distance, avoiding `sqrt()` calculations.
    * on_object_destroyed left as a no-op because no entities are registered via script.register_on_object_destroyed.
Cleanup relies on lazy validity checks: invalid endpoints are removed when the connection is used and found invalid.
If a partner mod wants immediate cleanup on destruction, they should unregister/disconnect in their own handler; we can reintroduce the handler logic if needed.
Single invalid surface-pair gets dropped on first failed use, so it won’t keep generating bad schedules.

3.  **Removed Redundant Database**:
    *   The `storage.se_elevators` database has been completely removed. Its role as a cache for the SE GUI has been replaced by dynamic, on-the-fly checks.

4.  **Backward Compatibility & Smooth Migration**:
    *   The existing `script.on_event` listener for SE's native teleportation events is fully preserved. **SE users will experience no change in functionality.**
    *   A migration script is included to clean up the old `se_elevators` database.
  
5.  **Implementation Notes**:
    *   **Internal Variable Naming**: The internal train flag `train.se_is_being_teleported` **has not been renamed**. While a generic name (e.g., `is_being_teleported`) would be semantically better, changing it would require modifying multiple core files (`central-planning.lua`, `train-events.lua`, etc.), significantly increasing the PR size and conflict risk. The new API wraps this flag, so the internal name remains an implementation detail to keep the diff minimal.
    *   **Symmetry Assumption**: The new API assumes connections are bidirectional (symmetric), inheriting Cybersyn's existing logic. For asymmetric (one-way) travel mods, this can still be handled by registering the connection and using station naming conventions to guide pathfinding, avoiding the need for a complete rewrite of Cybersyn's graph logic.

#### Regarding Maintenance

This refactoring was designed with **minimal maintenance burden** as a core principle:

1.  **No Change to Existing SE Logic Flow**: The core logic for handling SE events remains the same. Debugging any future SE-related issues will be identical to how it is done today.
2.  **Code Simplification**: We have actually *reduced* the complexity of the codebase by removing the redundant `se_elevators` database and all associated hard-coded logic. The new system is simpler and relies on a single source of truth.
3.  **Clear Separation of Concerns**: The new universal API is a thin layer that simply calls the same internal functions that the SE event listeners do. This isolates the universal entry point from the SE-specific one, making the code easier to understand and maintain.

In essence, this PR doesn't add a complex new feature to maintain; it refactors an existing feature to be more robust, more universal, and ultimately, *easier* to maintain in the long run.

