### PR TITLE
Automatically abort stuck provider-bound trains and return them to depot

### DIFF
--- a/cybersyn/locale/en/base.cfg
+++ b/cybersyn/locale/en/base.cfg
@@ -16,6 +16,7 @@ cybersyn-track-request-wait-times=Track request wait times
 cybersyn-allow-cargo-in-depot=Allow cargo in depots
 cybersyn-manager-updates-per-second=Manager updates per second
 cybersyn-manager-result-limit=Max entities displayed on GUI pages
+cybersyn-abort-stuck-train-to-depot=Abort stuck trains to depot
 
 [mod-setting-description]
 cybersyn-enable-planner=Enable or disable the central planning algorithm. If disabled no new trains will be dispatched.
@@ -35,6 +36,7 @@ cybersyn-track-request-wait-times=If checked, tracks how long stations have been
 cybersyn-allow-cargo-in-depot=If checked, trains will be allowed to have cargo in depots; no alerts will be generated and the train will not be held. In addition, trains with orders to visit requester stations with "Inactivity condition" checked will wait for inactivity instead of waiting for empty cargo. Useful for creating train systems where depots handle excess cargo. For advanced users only.
 cybersyn-manager-updates-per-second=Controls how frequently the Cybersyn manager gui refreshes. The Cybersyn manager must be set to active for this setting to have an effect.
 cybersyn-manager-result-limit=Caps the number of matching enitities (e.g. stations, trains) to limit the amount of update time consumed when the list is refreshed.\n-1 means return all results.
+cybersyn-abort-stuck-train-to-depot=When enabled, empty trains stuck while going to provider stations will automatically abort delivery and return to their depot.
 
 [item-name]
 cybersyn-combinator=Cybernetic combinator

--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -1281,6 +1281,14 @@ function abort_to_depot(map_data, train_id)
         return
     end
 
+	-- SE specific: Ensure the train is on the same entity with the depot (no need to interact with the elevator)
+	local rolling_stock = get_any_train_entity(train)
+	if not rolling_stock or rolling_stock.surface_index ~= depot.entity_stop.surface_index then
+        -- Debug output
+        game.print("Cybersyn Warning: Train stuck, managed by the Cybersyn, but has depot on another surface. Skipping for now.")
+		return
+	end
+
     -- 4. Clean the failed delivery (clean the manifests)
     on_failed_delivery(map_data, train_id, train_data)
 

--- a/cybersyn/scripts/central-planning.lua
+++ b/cybersyn/scripts/central-planning.lua
@@ -1243,7 +1243,10 @@ function abort_to_depot(map_data, train_id)
         return
     end
 
-    -- 4. Build new schedule
+    -- 4. Clean the failed delivery (clean the manifests)
+    on_failed_delivery(map_data, train_id, train_data)
+
+    -- 5. Build new schedule
     ---@type WaitCondition
     local condition_wait_inactive = { type = "inactivity", compare_type = "and", ticks = INACTIVITY_TIME }
     local schedule = train.get_schedule()
@@ -1254,18 +1257,18 @@ function abort_to_depot(map_data, train_id)
     schedule.clear_records()
     schedule.add_record(depot_record)
 
-    -- 5. Update Cybersyn state
+    -- 6. Update Cybersyn state
     train_data.status = STATUS_TO_D
-    train_data.manifest = nil
     if not train_data.use_any_depot then
         -- train using same depot, coord. station was inserted -> we need to color
         color_train_by_stop(train_data.entity, map_data.depots[train_data.depot_id].entity_stop)
     end
     interface_raise_train_status_changed(train_id, STATUS_TO_P, STATUS_TO_D)
 
+    -- 7. Debug output to console
     local gps_tag = ""
     if (train.front_stock and train.front_stock.valid) then
-		local entity = train.front_stock
+        local entity = train.front_stock
         local pos = entity.position
         gps_tag = string.format("[gps=%f,%f,%s]", pos.x, pos.y, entity.surface.name)
     end

--- a/cybersyn/scripts/main.lua
+++ b/cybersyn/scripts/main.lua
@@ -815,6 +815,7 @@ local function grab_all_settings()
 	mod_settings.track_request_wait_times = settings.global["cybersyn-track-request-wait-times"].value --[[@as boolean]]
 	mod_settings.allow_cargo_in_depot = settings.global["cybersyn-allow-cargo-in-depot"].value --[[@as boolean]]
 	mod_settings.manager_ups = settings.global["cybersyn-manager-updates-per-second"].value --[[@as double]]
+	mod_settings.abort_stuck_train_to_depot = settings.global["cybersyn-abort-stuck-train-to-depot"].value --[[@as boolean]]
 end
 local function register_tick()
 	script.on_nth_tick(nil)

--- a/cybersyn/settings.lua
+++ b/cybersyn/settings.lua
@@ -121,6 +121,13 @@ data:extend({
 		default_value = false,
 	},
 	{
+		type = "bool-setting",
+		name = "cybersyn-abort-stuck-train-to-depot",
+		order = "ce",
+		setting_type = "runtime-global",
+		default_value = false,
+	},
+	{
 		type = "double-setting",
 		name = "cybersyn-manager-updates-per-second",
 		order = "ad",


### PR DESCRIPTION
This PR adds an optional safety mechanism that automatically aborts deliveries when a Cybersyn-managed train becomes stuck while traveling to a provider station, and returns the train directly to its depot.

The goal is to prevent persistent rail deadlocks from blocking the network indefinitely, without requiring manual intervention or save corruption workarounds with badly designed rail networks.

The feature is gated behind a per-map setting and is disabled by default, so existing setups are unaffected unless the player opts in.

When Cybersyn detects a train that is not in manual mode, empty, traveling to a provider station (STATUS_TO_P), and flagged as stuck, the mod will cancel the delivery cleanly, uses existing on_failed_delivery logic to clean train manifests, updates station delivery accounting correctly, initializing the train to depot return. Then updates internal train state to STATUS_TO_D, override the schedule by replacing the schedule with a simple “go to depot” record (the same depot extracted from the previous schedule). Followed by the debug output to console with the GPS coords of the event.

Only English locale is provided at the moment.