### PR TITLE
fix: Allow temporary rail waypoints without removing train (Fixes #332)

### DIFF
--- a/cybersyn/scripts/train-events.lua
+++ b/cybersyn/scripts/train-events.lua
@@ -547,6 +547,14 @@ function on_train_changed(event)
 								on_train_arrives_refueler(map_data, station, train_id, train)
 							end
 						elseif is_station ~= nil then -- STATUS_TO_(P|R|F) but station is gone
+							local record = schedule.get_record({schedule_index = schedule.current})
+							if record and record.temporary and not record.station then
+								-- Allow temporary stops without removing the train from the network.
+								-- This is required for mods like Space Exploration, which insert temporary
+								-- waypoints when elevator exits are blocked.
+								-- If the train waits here too long, the standard 'stuck train' timeout will still trigger.
+								return
+							end
 							remove_train(map_data, train_id, train)
 							lock_train(train_e)
 							if is_station then


### PR DESCRIPTION
#### The Issue
Closes #332.

Currently, if a train stops at a temporary rail waypoint (e.g., inserted by Space Exploration's Space Elevator when the exit is blocked), Cybersyn detects that the train has stopped at a location that is not its target destination. Consequently, it removes the train from the logistics network

#### The Solution
This PR adds a specific check in `on_train_changed_state`.
If the train stops at a record that is **temporary** AND **has no station name** (identifying it as a coordinate-based rail waypoint), Cybersyn will simply ignore this event and let the train wait.

#### Why this approach?
I considered identifying whether the rail entity specifically belongs to the Space Elevator (e.g., checking `rail.name` against hardcoded SE entity names), or checking the previous station in the schedule. However, those methods would introduce:
1.  **Unnecessary complexity**: Requires maintaining a whitelist of modded entity names.
2.  ** brittleness**: Logic could break if other mods act similarly or if SE entity names change.

The proposed solution (`if record.temporary and not record.station`) is **generic, robust, and minimal**. It correctly identifies "waiting at a specific track coordinate"

#### Safety Note
This change is safe because Cybersyn's existing **Stuck Train Detection** logic remains active. If a train stays at this temporary waypoint for too long (exceeding the stuck threshold), the player will still be alerted, preventing trains from being silently lost in limbo. #
#