### PR TITLE
Hide analytics surface from map view on config change

### DIFF
--- a/cybersyn/info.json
+++ b/cybersyn/info.json
@@ -8,7 +8,7 @@
     "dependencies": [
         "base >= 2.0.60",
         "flib >= 0.15.0",
-        "? factorio-charts >= 1.0.5",
+        "? factorio-charts >= 1.0.7",
         "? space-exploration >= 0.6.94",
         "? miniloader",
         "? nullius",

--- a/cybersyn/scripts/migrations.lua
+++ b/cybersyn/scripts/migrations.lua
@@ -491,6 +491,13 @@ function on_config_changed(config_change_data)
 		analytics.init(storage)
 	end
 
+	-- Ensure analytics surface is hidden from map view for all forces
+	if storage.analytics and storage.analytics.surface then
+		for _, force in pairs(game.forces) do
+			force.set_surface_hidden(storage.analytics.surface, true)
+		end
+	end
+
 	retrigger_train_calculation(false)
 end
 


### PR DESCRIPTION
Ensure the analytics surface is hidden for all forces during on_configuration_changed to handle existing saves.