### PR TITLE
Add internal item selections to recent items header bar

### DIFF
--- a/cybersyn/scripts/gui/inventory.lua
+++ b/cybersyn/scripts/gui/inventory.lua
@@ -444,6 +444,8 @@ function inventory_tab.handle.on_inventory_item_click(player, player_data, refs,
 		refs.manager_item_filter.elem_value = signal
 		player_data.search_item = item_name
 		interface_raise_item_selected(e.player_index, item_name)
+		interop_add_recent_item(e.player_index, item_name, "cybersyn")
+		player_data.recent_panel_dirty = true
 
 		-- Switch to stations tab
 		local tabbed_pane = refs.manager_tabbed_pane

--- a/cybersyn/scripts/gui/manager.lua
+++ b/cybersyn/scripts/gui/manager.lua
@@ -356,6 +356,8 @@ function manager.handle.manager_update_item_search(player, player_data, refs, e)
 	if signal then
 		player_data.search_item = signal.name
 		interface_raise_item_selected(e.player_index, signal.name)
+		interop_add_recent_item(e.player_index, signal.name, "cybersyn")
+		player_data.recent_panel_dirty = true
 	else
 		player_data.search_item = nil
 	end
@@ -423,6 +425,8 @@ function manager.handle.recent_item_click(player, player_data, refs, e)
 			refs.manager_item_filter.elem_value = util.signalid_from_name(tags.item_name)
 		end
 		interface_raise_item_selected(e.player_index, tags.item_name)
+		interop_add_recent_item(e.player_index, tags.item_name, "cybersyn")
+		player_data.recent_panel_dirty = true
 	end
 end
 


### PR DESCRIPTION
When a user selects an item via the filter chooser or clicks a recent item in the header bar, the item is now added to the recent items list. This makes the header bar serve as a history of all recently viewed items, not just items received from other mods via interop.