### PR TITLE
Show incoming Cybersyn trains in vanilla train stop UI

### DIFF
--- a/cybersyn/scripts/factorio-api.lua
+++ b/cybersyn/scripts/factorio-api.lua
@@ -425,12 +425,21 @@ end
 ---Adds a temporary rail record for the given train stop if there was no previous surface travel.
 ---@param stop LuaEntity? invalid stops are skipped
 function ScheduleBuilder:add_direct_to_stop(stop)
-	if self.same_surface and stop and stop.valid then
-		local i = self.i + 1
-		self.records[i] = create_direct_to_station_order(stop)
-		self.stops[i] = stop
-		self.i = i
-	end
+    if self.same_surface and stop and stop.valid then
+        local i = self.i + 1
+        -- UI visibility record: named stop with instant pass condition
+        self.records[i] = {
+            station = stop.backer_name,
+            wait_conditions = {{ type = "time", compare_type = "and", ticks = 0 }},
+            temporary = true,
+            tags = { cybersyn_ui_only = true },
+        }
+        self.stops[i] = stop
+        self.i = i + 1
+        -- Actual coordinate stop for routing
+        self.records[self.i] = create_direct_to_station_order(stop)
+        self.stops[self.i] = stop
+    end
 end
 
 ---@param p_stop LuaEntity


### PR DESCRIPTION
Adds a zero-tick temporary named station record before each coordinate stop in the train schedule. This makes the vanilla train stop UI show incoming Cybersyn trains under "Trains on the way", which was previously not possible because Cybersyn used coordinate stops that Factorio's UI couldn't associate with a named station.
The coordinate stop remains unchanged so Cybersyn's routing logic is unaffected. The zero-tick wait condition means the UI record passes instantly before the coordinate stop takes over.